### PR TITLE
Fixed false positive on if and opening parenthesis

### DIFF
--- a/src/Allocine/TwigLinter/Rule/ParenthesisSpacing.php
+++ b/src/Allocine/TwigLinter/Rule/ParenthesisSpacing.php
@@ -13,14 +13,20 @@ class ParenthesisSpacing extends AbstractSpacingRule implements RuleInterface
     private $spacing;
 
     /**
+     * @var integer
+     */
+    private $controlStructureSpacing;
+
+    /**
      * @param integer $severity
      * @param integer $spacing
      */
-    public function __construct($severity, $spacing = 0)
+    public function __construct($severity, $spacing = 0, $controlStructureSpacing = 1)
     {
         parent::__construct($severity);
 
         $this->spacing = $spacing;
+        $this->controlStructureSpacing = $controlStructureSpacing;
     }
 
     /**
@@ -37,8 +43,11 @@ class ParenthesisSpacing extends AbstractSpacingRule implements RuleInterface
                 $this->assertSpacing($tokens, Lexer::NEXT_TOKEN, $this->spacing);
 
                 // Space allowed if previous token is not a function name.
+                // Space also allowed in case of control structure
                 if ($tokens->look(-2)->getType() === \Twig_Token::NAME_TYPE) {
-                    $this->assertSpacing($tokens, Lexer::PREVIOUS_TOKEN, $this->spacing);
+                    $value = $tokens->look(-2)->getValue();
+                    $spacing = in_array($value, ['if', 'elseif', 'in']) ? $this->controlStructureSpacing : $this->spacing;
+                    $this->assertSpacing($tokens, Lexer::PREVIOUS_TOKEN, $spacing);
                 }
             }
 

--- a/src/Allocine/TwigLinter/Ruleset/Official.php
+++ b/src/Allocine/TwigLinter/Ruleset/Official.php
@@ -15,7 +15,7 @@ class Official implements RulesetInterface
     {
         return [
             new Rule\DelimiterSpacing(Violation::SEVERITY_WARNING, 1),
-            new Rule\ParenthesisSpacing(Violation::SEVERITY_WARNING, 0),
+            new Rule\ParenthesisSpacing(Violation::SEVERITY_WARNING, 0, 1),
             new Rule\ArraySeparatorSpacing(Violation::SEVERITY_WARNING, 0, 1),
             new Rule\OperatorSpacing(Violation::SEVERITY_WARNING, [
                 '==', '!=', '<', '>', '>=', '<=',

--- a/src/Allocine/TwigLinter/Tests/FunctionalTest.php
+++ b/src/Allocine/TwigLinter/Tests/FunctionalTest.php
@@ -49,6 +49,12 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
             ['{{ ( 1) }}',    'There should be no space after "(".'],
             ['{{ (1 ) }}',    'There should be no space before ")".'],
 
+            // Parenthesis spacing is not appliable to control structures.
+            ['{% if (1 + 2) == 3 %}', null],
+            ['{% for i in (some_array) %}', null],
+            ['{% for i in  (some_array) %}', 'More than 1 space(s) found after "in".'],
+            ['{% if  (1 + 2) == 3 %}', 'More than 1 space(s) found before "(".'],
+
             // Do not put any spaces before and after the following operators: |, ., .., [].
             ['{{ foo|baz }}', null],
             ['{{ foo[0] }}', null],


### PR DESCRIPTION
This introduces a new setting on the ParenthesisSpacing rule that allows to define the number of spaces allowed between the control structure name and the first opening parenthesis.

See added tests for examples.
