### PR TITLE
Added checkstyle reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ twigcs lint /path/to/views --severity warning # Allow notices
 
 With the example above, notices are still displayed but not altering the exit code.
 
+### Continuous Integration
+
+Twigcs can be used with your favorite CI server. The command itself will return a consistent exit code telling
+the CI job if it failed or succeeded. You can also have a nice xml report (checkstyle format) :
+
+```bash
+twigcs lint /path/to/views --reporter checkstyle > /path/to/report.xml
+```
+
 ### Coding standard
 
 At the moment the only supported standard is the [official one from twig](http://twig.sensiolabs.org/doc/coding_standards.html).
@@ -42,8 +51,6 @@ At the moment the only supported standard is the [official one from twig](http:/
 ### Coming features
 
 - Indentation checking
-- Unused variables/macros checking
-- CI-friendly reporter (creating file-based checkstyle reports)
 - Configurable coding standards
 
 ### Contributing

--- a/src/Allocine/TwigLinter/Container.php
+++ b/src/Allocine/TwigLinter/Container.php
@@ -3,6 +3,7 @@
 namespace Allocine\TwigLinter;
 
 use Allocine\TwigLinter\Lexer;
+use Allocine\TwigLinter\Reporter\CheckstyleReporter;
 use Allocine\TwigLinter\Reporter\ConsoleReporter;
 use Allocine\TwigLinter\Validator\Validator;
 use Pimple\Container as BaseContainer;
@@ -13,6 +14,10 @@ class Container extends BaseContainer
     {
         $this['reporter.console'] = function () {
             return new ConsoleReporter();
+        };
+
+        $this['reporter.checkstyle'] = function () {
+            return new CheckstyleReporter();
         };
 
         $this['twig'] = function ($container) {

--- a/src/Allocine/TwigLinter/Lexer.php
+++ b/src/Allocine/TwigLinter/Lexer.php
@@ -4,12 +4,13 @@ namespace Allocine\TwigLinter;
 
 class Lexer extends \Twig_Lexer
 {
-    const WHITESPACE_TYPE = 12;
-    const NEWLINE_TYPE    = 13;
-
     const PREVIOUS_TOKEN = -1;
     const NEXT_TOKEN     = 1;
 
+    /**
+     * @var integer
+     */
+    protected $columnno = 0;
 
     protected function lexExpression()
     {
@@ -19,9 +20,9 @@ class Lexer extends \Twig_Lexer
 
             foreach ($emptyLines as $line) {
                 if (strlen($line) == 0) {
-                    $this->pushToken(self::NEWLINE_TYPE);
+                    $this->pushToken(Token::NEWLINE_TYPE);
                 } else {
-                    $this->pushToken(self::WHITESPACE_TYPE, $line);
+                    $this->pushToken(Token::WHITESPACE_TYPE, $line);
                 }
             }
 
@@ -35,7 +36,7 @@ class Lexer extends \Twig_Lexer
         if (empty($this->brackets) && preg_match($this->regexes['lex_block'], $this->code, $match, null, $this->cursor)) {
             // Collect whitespaces in end blocks
             if (preg_match('/^(\s+)/', $match[0], $spaces)) {
-                $this->pushToken(self::WHITESPACE_TYPE, $spaces[0]);
+                $this->pushToken(Token::WHITESPACE_TYPE, $spaces[0]);
             }
 
             $this->pushToken(\Twig_Token::BLOCK_END_TYPE);
@@ -51,7 +52,7 @@ class Lexer extends \Twig_Lexer
         if (empty($this->brackets) && preg_match($this->regexes['lex_var'], $this->code, $match, null, $this->cursor)) {
             // Collect whitespaces in end blocks
             if (preg_match('/^(\s+)/', $match[0], $spaces)) {
-                $this->pushToken(self::WHITESPACE_TYPE, $spaces[0]);
+                $this->pushToken(Token::WHITESPACE_TYPE, $spaces[0]);
             }
 
             $this->pushToken(\Twig_Token::VAR_END_TYPE);
@@ -60,5 +61,37 @@ class Lexer extends \Twig_Lexer
         } else {
             $this->lexExpression();
         }
+    }
+
+    /**
+     * @param int    $type
+     * @param string $value
+     */
+    protected function pushToken($type, $value = '')
+    {
+        // do not push empty text tokens
+        if (Token::TEXT_TYPE === $type && '' === $value) {
+            return;
+        }
+
+        // The base lexer doesn't call moveCursor when encountering punctuations. (See class \Twig_Lexer line 269)
+        if ($type == \Twig_Token::PUNCTUATION_TYPE) {
+            $this->columnno++;
+        }
+
+        $this->tokens[] = new Token($type, $value, $this->lineno, $this->columnno);
+    }
+
+    /**
+     * @param string $text
+     */
+    protected function moveCursor($text)
+    {
+        $lineCount = substr_count($text, "\n");
+        $movement = strlen($text);
+
+        $this->cursor += $movement;
+        $this->lineno += $lineCount;
+        $this->columnno = $lineCount ? strlen(substr($text, strrpos($text, "\n") + 1)) : ($this->columnno + $movement);
     }
 }

--- a/src/Allocine/TwigLinter/Reporter/CheckstyleReporter.php
+++ b/src/Allocine/TwigLinter/Reporter/CheckstyleReporter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Allocine\TwigLinter\Reporter;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CheckstyleReporter implements ReporterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function report(OutputInterface $output, array $violations)
+    {
+        $filename = null;
+        $filenode = null;
+
+        $checkstyle = new \SimpleXMLElement('<checkstyle version="1.0.0"/>');
+
+        foreach ($violations as $violation) {
+            if ($filename != $violation->getFilename()) {
+                $filename = $violation->getFilename();
+                $filenode = $checkstyle->addChild('file');
+                $filenode->addAttribute('path', $filename);
+            }
+
+            $error = $filenode->addChild('error');
+            $error->addAttribute('column', $violation->getColumn());
+            $error->addAttribute('line', $violation->getLine());
+            $error->addAttribute('severity', strtolower($violation->getSeverityAsString()));
+            $error->addAttribute('message', $violation->getReason());
+            $error->addAttribute('source', $violation->getSource());
+
+        }
+
+        $output->writeln($checkstyle->asXML());
+    }
+}

--- a/src/Allocine/TwigLinter/Reporter/ConsoleReporter.php
+++ b/src/Allocine/TwigLinter/Reporter/ConsoleReporter.php
@@ -20,8 +20,9 @@ class ConsoleReporter implements ReporterInterface
             }
 
             $output->writeln(sprintf(
-                '<comment>l.%d</comment> : %s %s',
+                '<comment>l.%d c.%d</comment> : %s %s',
                 $violation->getLine(),
+                $violation->getColumn(),
                 $violation->getSeverityAsString(),
                 $violation->getReason()
             ));

--- a/src/Allocine/TwigLinter/Rule/AbstractRule.php
+++ b/src/Allocine/TwigLinter/Rule/AbstractRule.php
@@ -34,8 +34,8 @@ class AbstractRule
      * @param integer $line
      * @param string $reason
      */
-    public function addViolation($filename, $line, $reason)
+    public function addViolation($filename, $line, $column, $reason)
     {
-        $this->violations[] = new Violation($filename, $line, $reason, $this->severity);
+        $this->violations[] = new Violation($filename, $line, $column, $reason, $this->severity, get_called_class());
     }
 }

--- a/src/Allocine/TwigLinter/Rule/AbstractSpacingRule.php
+++ b/src/Allocine/TwigLinter/Rule/AbstractSpacingRule.php
@@ -2,7 +2,7 @@
 
 namespace Allocine\TwigLinter\Rule;
 
-use Allocine\TwigLinter\Lexer;
+use Allocine\TwigLinter\Token;
 use Allocine\TwigLinter\Validator\Violation;
 use Allocine\TwigLinter\Whistelist\WhitelistInterface;
 
@@ -41,24 +41,26 @@ class AbstractSpacingRule extends AbstractRule
             return;
         }
 
-        if ($acceptNewLines && $token->getType() == Lexer::NEWLINE_TYPE) {
+        if ($acceptNewLines && $token->getType() == Token::NEWLINE_TYPE) {
             return;
         }
 
         // special case of no spaces allowed.
         if ($spacing === 0) {
-            if ($token->getType() === Lexer::WHITESPACE_TYPE) {
+            if ($token->getType() === Token::WHITESPACE_TYPE) {
                 $this->addViolation(
                     $tokens->getFilename(),
-                    $token->getLine(),
+                    $current->getLine(),
+                    $current->getColumn(),
                     sprintf('There should be no space %s "%s".', $positionName, $current->getValue())
                 );
             }
 
-            if ($token->getType() === Lexer::NEWLINE_TYPE) {
+            if ($token->getType() === Token::NEWLINE_TYPE) {
                 $this->addViolation(
                     $tokens->getFilename(),
-                    $token->getLine(),
+                    $current->getLine(),
+                    $current->getColumn(),
                     sprintf('There should be no new line %s "%s".', $positionName, $current->getValue())
                 );
             }
@@ -66,18 +68,20 @@ class AbstractSpacingRule extends AbstractRule
             return;
         }
 
-        if ($token->getType() !== Lexer::WHITESPACE_TYPE || strlen($token->getValue()) < $spacing) {
+        if ($token->getType() !== Token::WHITESPACE_TYPE || strlen($token->getValue()) < $spacing) {
             $this->addViolation(
                 $tokens->getFilename(),
-                $token->getLine(),
+                $current->getLine(),
+                $current->getColumn(),
                 sprintf('There should be %d space(s) %s "%s".', $spacing, $positionName, $current->getValue())
             );
         }
 
-        if ($token->getType() === Lexer::WHITESPACE_TYPE && strlen($token->getValue()) > $spacing) {
+        if ($token->getType() === Token::WHITESPACE_TYPE && strlen($token->getValue()) > $spacing) {
             $this->addViolation(
                 $tokens->getFilename(),
-                $token->getLine(),
+                $current->getLine(),
+                $current->getColumn(),
                 sprintf('More than %d space(s) found %s "%s".', $spacing, $positionName, $current->getValue())
             );
         }

--- a/src/Allocine/TwigLinter/Rule/DelimiterSpacing.php
+++ b/src/Allocine/TwigLinter/Rule/DelimiterSpacing.php
@@ -3,6 +3,7 @@
 namespace Allocine\TwigLinter\Rule;
 
 use Allocine\TwigLinter\Lexer;
+use Allocine\TwigLinter\Token;
 use Allocine\TwigLinter\Validator\Violation;
 
 class DelimiterSpacing extends AbstractRule implements RuleInterface
@@ -57,18 +58,20 @@ class DelimiterSpacing extends AbstractRule implements RuleInterface
     {
         $token = $tokens->look($position);
 
-        if ($token->getType() !== Lexer::WHITESPACE_TYPE || strlen($token->getValue()) < $this->spacing) {
+        if ($token->getType() !== Token::WHITESPACE_TYPE || strlen($token->getValue()) < $this->spacing) {
             $this->addViolation(
                 $tokens->getFilename(),
                 $token->getLine(),
+                $token->getColumn(),
                 sprintf('There should be %d space(s) %s.', $this->spacing, $target)
             );
         }
 
-        if ($token->getType() === Lexer::WHITESPACE_TYPE && strlen($token->getValue()) > $this->spacing) {
+        if ($token->getType() === Token::WHITESPACE_TYPE && strlen($token->getValue()) > $this->spacing) {
             $this->addViolation(
                 $tokens->getFilename(),
                 $token->getLine(),
+                $token->getColumn(),
                 sprintf('More than %d space(s) found %s.', $this->spacing, $target)
             );
         }

--- a/src/Allocine/TwigLinter/Rule/LowerCaseVariable.php
+++ b/src/Allocine/TwigLinter/Rule/LowerCaseVariable.php
@@ -3,6 +3,7 @@
 namespace Allocine\TwigLinter\Rule;
 
 use Allocine\TwigLinter\Lexer;
+use Allocine\TwigLinter\Token;
 use Allocine\TwigLinter\Validator\Violation;
 
 class LowerCaseVariable extends AbstractRule implements RuleInterface
@@ -18,8 +19,8 @@ class LowerCaseVariable extends AbstractRule implements RuleInterface
             $token = $tokens->getCurrent();
 
             if ($token->getType() === \Twig_Token::NAME_TYPE && preg_match('/[A-Z]/', $token->getValue())) {
-                if ($tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Lexer::WHITESPACE_TYPE && $tokens->look(-2)->getValue() === 'set') {
-                    $this->addViolation($tokens->getFilename(), $token->getLine(), sprintf('The "%s" variable should be in lower case (use _ as a separator).', $token->getValue()));
+                if ($tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Token::WHITESPACE_TYPE && $tokens->look(-2)->getValue() === 'set') {
+                    $this->addViolation($tokens->getFilename(), $token->getLine(), $token->getColumn(), sprintf('The "%s" variable should be in lower case (use _ as a separator).', $token->getValue()));
                 }
             }
 

--- a/src/Allocine/TwigLinter/Rule/ParenthesisSpacing.php
+++ b/src/Allocine/TwigLinter/Rule/ParenthesisSpacing.php
@@ -3,6 +3,7 @@
 namespace Allocine\TwigLinter\Rule;
 
 use Allocine\TwigLinter\Lexer;
+use Allocine\TwigLinter\Token;
 use Allocine\TwigLinter\Validator\Violation;
 
 class ParenthesisSpacing extends AbstractSpacingRule implements RuleInterface
@@ -51,7 +52,7 @@ class ParenthesisSpacing extends AbstractSpacingRule implements RuleInterface
                 }
             }
 
-            if ($token->getValue() === ')' && $tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Lexer::WHITESPACE_TYPE) {
+            if ($token->getValue() === ')' && $tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Token::WHITESPACE_TYPE) {
                 $this->assertSpacing($tokens, Lexer::PREVIOUS_TOKEN, $this->spacing);
             }
 

--- a/src/Allocine/TwigLinter/Rule/UnusedMacro.php
+++ b/src/Allocine/TwigLinter/Rule/UnusedMacro.php
@@ -2,7 +2,7 @@
 
 namespace Allocine\TwigLinter\Rule;
 
-use Allocine\TwigLinter\Lexer;
+use Allocine\TwigLinter\Token;
 
 class UnusedMacro extends AbstractRule implements RuleInterface
 {
@@ -25,10 +25,10 @@ class UnusedMacro extends AbstractRule implements RuleInterface
 
                 $tokens->next();
 
-                while (in_array($tokens->getCurrent()->getType(), [\Twig_Token::NAME_TYPE, \Twig_Token::PUNCTUATION_TYPE, Lexer::WHITESPACE_TYPE])) {
+                while (in_array($tokens->getCurrent()->getType(), [\Twig_Token::NAME_TYPE, \Twig_Token::PUNCTUATION_TYPE, Token::WHITESPACE_TYPE])) {
                     $next = $tokens->getCurrent();
                     if ($next->getType() === \Twig_Token::NAME_TYPE) {
-                        $macros[$next->getValue()] = $next->getLine();
+                        $macros[$next->getValue()] = $next;
                     }
 
                     $tokens->next();
@@ -41,10 +41,11 @@ class UnusedMacro extends AbstractRule implements RuleInterface
         }
 
 
-        foreach ($macros as $name => $line) {
+        foreach ($macros as $name => $originalToken) {
             $this->addViolation(
                 $tokens->getFilename(),
-                $token->getLine(),
+                $originalToken->getLine(),
+                $originalToken->getColumn(),
                 sprintf('Unused macro "%s".', $name)
             );
         }

--- a/src/Allocine/TwigLinter/Rule/UnusedVariable.php
+++ b/src/Allocine/TwigLinter/Rule/UnusedVariable.php
@@ -3,6 +3,7 @@
 namespace Allocine\TwigLinter\Rule;
 
 use Allocine\TwigLinter\Lexer;
+use Allocine\TwigLinter\Token;
 
 class UnusedVariable extends AbstractRule implements RuleInterface
 {
@@ -19,8 +20,8 @@ class UnusedVariable extends AbstractRule implements RuleInterface
             $token = $tokens->getCurrent();
 
             if ($token->getType() === \Twig_Token::NAME_TYPE) {
-                if ($tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Lexer::WHITESPACE_TYPE && $tokens->look(-2)->getValue() === 'set') {
-                    $variables[$token->getValue()] = $token->getLine();
+                if ($tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Token::WHITESPACE_TYPE && $tokens->look(-2)->getValue() === 'set') {
+                    $variables[$token->getValue()] = $token;
                 } else {
                     unset($variables[$token->getValue()]);
                 }
@@ -29,10 +30,11 @@ class UnusedVariable extends AbstractRule implements RuleInterface
             $tokens->next();
         }
 
-        foreach ($variables as $name => $line) {
+        foreach ($variables as $name => $originalToken) {
             $this->addViolation(
                 $tokens->getFilename(),
-                $token->getLine(),
+                $originalToken->getLine(),
+                $originalToken->getColumn(),
                 sprintf('Unused variable "%s".', $name)
             );
         }

--- a/src/Allocine/TwigLinter/Token.php
+++ b/src/Allocine/TwigLinter/Token.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Allocine\TwigLinter;
+
+class Token extends \Twig_Token
+{
+    const WHITESPACE_TYPE = 12;
+    const NEWLINE_TYPE    = 13;
+
+    /**
+     * @var int
+     */
+    private $columnno;
+
+    /**
+     * @param int    $type
+     * @param string $value
+     * @param int    $lineno
+     * @param int    $columnno
+     */
+    public function __construct($type, $value, $lineno, $columnno)
+    {
+        parent::__construct($type, $value, $lineno);
+
+        $this->columnno = $columnno;
+    }
+
+    /**
+     * @return int
+     */
+    public function getColumn()
+    {
+        return $this->columnno;
+    }
+
+    /**
+     * @param string  $type
+     * @param boolean $short
+     *
+     * @return string
+     */
+    public static function typeToString($type, $short = false)
+    {
+        if ($type === self::WHITESPACE_TYPE) {
+            return $short ? 'WHITESPACE_TYPE' : 'Twig_Token::WHITESPACE_TYPE';
+        }
+
+        if ($type === self::NEWLINE_TYPE) {
+            return $short ? 'NEWLINE_TYPE' : 'Twig_Token::NEWLINE_TYPE';
+        }
+
+        return \Twig_Token::typeToString($type, $short);
+    }
+}

--- a/src/Allocine/TwigLinter/Validator/Violation.php
+++ b/src/Allocine/TwigLinter/Validator/Violation.php
@@ -9,9 +9,14 @@ class Violation
     const SEVERITY_FATAL   = 3;
 
     /**
-     * @var integer
+     * @var int
      */
     private $line;
+
+    /**
+     * @var int
+     */
+    private $column;
 
     /**
      * @var string
@@ -24,29 +29,44 @@ class Violation
     private $filename;
 
     /**
-     * @var integer
+     * @var int
      */
     private $severity;
 
     /**
+     * @var string
+     */
+    private $source;
+
+    /**
      * @param string  $filename
-     * @param integer $line
+     * @param int     $line
      * @param string  $reason
      */
-    public function __construct($filename, $line, $reason, $severity = Violation::SEVERITY_FATAL)
+    public function __construct($filename, $line, $column, $reason, $severity = Violation::SEVERITY_FATAL, $source = 'unknown')
     {
         $this->filename = $filename;
         $this->line     = $line;
+        $this->column   = $column;
         $this->reason   = $reason;
         $this->severity = $severity;
+        $this->source   = $source;
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getLine()
     {
         return $this->line;
+    }
+
+    /**
+     * @return int
+     */
+    public function getColumn()
+    {
+        return $this->column;
     }
 
     /**
@@ -66,7 +86,7 @@ class Violation
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getSeverity()
     {
@@ -79,5 +99,13 @@ class Violation
     public function getSeverityAsString()
     {
         return ['NOTICE', 'WARNING', 'FATAL'][$this->severity - 1];
+    }
+
+    /**
+     * @return string
+     */
+    public function getSource()
+    {
+        return $this->source;
     }
 }


### PR DESCRIPTION
This adds a checkstyle reporter that will allow CI servers like Jenkins to parse the checkstyle results.

To use it, just run : `bin/twigcs lint /my/views -r checkstyle > report.xml`.

In the background, this PR introduces columns and sources for violations as they are needed by the xml checkstyle results.

The column number was also added to the human readable reporter to make error spotting easier.
