### PR TITLE
Fixed complex ternaries cases, splitted array and hashes spacing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ At the moment the only supported standard is the [official one from twig](http:/
 
 The master is the development branch, if you find any bug or false positive during style checking, please
 open an issue or submit a pull request.
+
+When creating or changing a class, don't forget to add you as an `@author` at the top of the file.

--- a/src/Allocine/TwigLinter/Rule/AbstractRule.php
+++ b/src/Allocine/TwigLinter/Rule/AbstractRule.php
@@ -2,9 +2,16 @@
 
 namespace Allocine\TwigLinter\Rule;
 
+use Allocine\TwigLinter\Token;
 use Allocine\TwigLinter\Validator\Violation;
 
-class AbstractRule
+/**
+ * This is an utility class that provides some common functionnalities
+ * for rule creation.
+ *
+ * @author Tristan Maindron <tmaindron@gmail.com>
+ */
+abstract class AbstractRule
 {
     /**
      * @var integer
@@ -37,5 +44,31 @@ class AbstractRule
     public function addViolation($filename, $line, $column, $reason)
     {
         $this->violations[] = new Violation($filename, $line, $column, $reason, $this->severity, get_called_class());
+    }
+
+    /**
+     * @param \Twig_TokenStream $tokens
+     * @param integer           $skip
+     *
+     * @return null|Token
+     */
+    protected function getPreviousSignicantToken(\Twig_TokenStream $tokens, $skip = 0)
+    {
+        $i = 1;
+        $token = null;
+
+        while ($token = $tokens->look(-$i)) {
+            if (!in_array($token->getType(), [Token::WHITESPACE_TYPE, Token::NEWLINE_TYPE])) {
+                if ($skip === 0) {
+                    return $token;
+                }
+
+                $skip--;
+            }
+
+            $i++;
+        }
+
+        return null;
     }
 }

--- a/src/Allocine/TwigLinter/Rule/ParenthesisSpacing.php
+++ b/src/Allocine/TwigLinter/Rule/ParenthesisSpacing.php
@@ -6,6 +6,17 @@ use Allocine\TwigLinter\Lexer;
 use Allocine\TwigLinter\Token;
 use Allocine\TwigLinter\Validator\Violation;
 
+/**
+ * This rule enforces spacing around parenthesis. The expected spacing
+ * can be tweaked in case of control structure.
+ *
+ * By default, the following are considered valids :
+ * - {{ (1 + 2) }}
+ * - {{ func(1) }}
+ * - {% if (1 > 2) %}
+ *
+ * @author Tristan Maindron <tmaindron@gmail.com>
+ */
 class ParenthesisSpacing extends AbstractSpacingRule implements RuleInterface
 {
     /**
@@ -40,7 +51,7 @@ class ParenthesisSpacing extends AbstractSpacingRule implements RuleInterface
         while (!$tokens->isEOF()) {
             $token = $tokens->getCurrent();
 
-            if ($token->getValue() === '(') {
+            if ($token->getValue() === '(' && $token->getType() === \Twig_Token::PUNCTUATION_TYPE) {
                 $this->assertSpacing($tokens, Lexer::NEXT_TOKEN, $this->spacing);
 
                 // Space allowed if previous token is not a function name.
@@ -52,7 +63,7 @@ class ParenthesisSpacing extends AbstractSpacingRule implements RuleInterface
                 }
             }
 
-            if ($token->getValue() === ')' && $tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Token::WHITESPACE_TYPE) {
+            if ($token->getValue() === ')' && $token->getType() === \Twig_Token::PUNCTUATION_TYPE && $tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Token::WHITESPACE_TYPE) {
                 $this->assertSpacing($tokens, Lexer::PREVIOUS_TOKEN, $this->spacing);
             }
 

--- a/src/Allocine/TwigLinter/Rule/TernarySpacing.php
+++ b/src/Allocine/TwigLinter/Rule/TernarySpacing.php
@@ -5,10 +5,15 @@ namespace Allocine\TwigLinter\Rule;
 use Allocine\TwigLinter\Lexer;
 use Allocine\TwigLinter\Validator\Violation;
 
+/**
+ * This rule enforces spacing inside ternaries.
+ *
+ * By default, the following are considered valids : condition ? "val1" : "val2"
+ *
+ * @author Tristan Maindron <tmaindron@gmail.com>
+ */
 class TernarySpacing extends AbstractSpacingRule implements RuleInterface
 {
-    const TERNARY_PUNCTUATION = ['if' => '?', 'else' => ':'];
-
     /**
      * @var integer
      */
@@ -33,32 +38,76 @@ class TernarySpacing extends AbstractSpacingRule implements RuleInterface
         $this->violations = [];
         $ternaryDepth = 0;
 
+        $closingTokens = [];
+
         while (!$tokens->isEOF()) {
             $token = $tokens->getCurrent();
 
-            if ($token->getValue() === self::TERNARY_PUNCTUATION['if']) {
-                $ternaryDepth++;
+            if ($token->getValue() === '?' && $token->getType() === \Twig_Token::PUNCTUATION_TYPE) {
+                // Memorize where is the closing ":" punctuation to validate spacing later.
+                $closingTokens[] = $this->seekTernaryElse($tokens);
+
+                $next = $tokens->look(Lexer::NEXT_TOKEN);
+
+                if ($next->getValue() !== ':') {
+                    $this->assertSpacing($tokens, Lexer::NEXT_TOKEN, $this->spacing);
+                }
+
+                $this->assertSpacing($tokens, Lexer::PREVIOUS_TOKEN, $this->spacing);
             }
 
-            if ($ternaryDepth > 0 && $token->getType() === \Twig_Token::PUNCTUATION_TYPE && in_array($token->getValue(), self::TERNARY_PUNCTUATION)) {
+            if (in_array($token, $closingTokens)) {
                 $previous = $tokens->look(Lexer::PREVIOUS_TOKEN);
-                $next = $tokens->look(Lexer::NEXT_TOKEN);
 
                 if ($previous->getValue() !== '?') {
                     $this->assertSpacing($tokens, Lexer::PREVIOUS_TOKEN, $this->spacing);
                 }
-                if ($next->getValue() !== ':') {
-                    $this->assertSpacing($tokens, Lexer::NEXT_TOKEN, $this->spacing);
-                }
-            }
 
-            if ($token->getValue() === self::TERNARY_PUNCTUATION['else']) {
-                $ternaryDepth = max(0, $ternaryDepth - 1);
+                $this->assertSpacing($tokens, Lexer::NEXT_TOKEN, $this->spacing);
             }
 
             $tokens->next();
         }
 
         return $this->violations;
+    }
+
+    /**
+     * @param \Twig_TokenStream $tokens
+     *
+     * @return \Twig_Token
+     */
+    protected function seekTernaryElse(\Twig_TokenStream $tokens)
+    {
+        $i = 1;
+        $depth = 0;
+        $found = false;
+        $token = null;
+
+        while ($depth || !$found) {
+            $token = $tokens->look($i);
+
+            if ($token->getType() === \Twig_Token::VAR_END_TYPE || $token->getType() === \Twig_Token::INTERPOLATION_END_TYPE) {
+                return;
+            }
+
+            // End of hash value means end of short ternary (eg. "foo ? bar" syntax)
+            if ($token->getType() === \Twig_Token::PUNCTUATION_TYPE && $token->getValue() === ',') {
+                return;
+            }
+
+            if ($token->getType() === \Twig_Token::PUNCTUATION_TYPE && in_array($token->getValue(), ['(', '[', '{'])) {
+                $depth++;
+            }
+
+            if ($depth && $token->getType() === \Twig_Token::PUNCTUATION_TYPE && in_array($token->getValue(), [')', ']', '}'])) {
+                $depth--;
+            }
+
+            $found = $token->getType() === \Twig_Token::PUNCTUATION_TYPE && $token->getValue() === ':';
+            $i++;
+        }
+
+        return $token;
     }
 }

--- a/src/Allocine/TwigLinter/Ruleset/Official.php
+++ b/src/Allocine/TwigLinter/Ruleset/Official.php
@@ -6,6 +6,11 @@ use Allocine\TwigLinter\Rule;
 use Allocine\TwigLinter\Validator\Violation;
 use Allocine\TwigLinter\Whistelist\TokenWhitelist;
 
+/**
+ * The official twigcs ruleset, based on http://twig.sensiolabs.org/doc/coding_standards.html
+ *
+ * @author Tristan Maindron <tmaindron@gmail.com>
+ */
 class Official implements RulesetInterface
 {
     /**
@@ -17,6 +22,7 @@ class Official implements RulesetInterface
             new Rule\DelimiterSpacing(Violation::SEVERITY_WARNING, 1),
             new Rule\ParenthesisSpacing(Violation::SEVERITY_WARNING, 0, 1),
             new Rule\ArraySeparatorSpacing(Violation::SEVERITY_WARNING, 0, 1),
+            new Rule\HashSeparatorSpacing(Violation::SEVERITY_WARNING, 0, 1),
             new Rule\OperatorSpacing(Violation::SEVERITY_WARNING, [
                 '==', '!=', '<', '>', '>=', '<=',
                 '+', '-', '/', '*', '%', '//', '**',

--- a/src/Allocine/TwigLinter/Tests/FunctionalTest.php
+++ b/src/Allocine/TwigLinter/Tests/FunctionalTest.php
@@ -6,6 +6,11 @@ use Allocine\TwigLinter\Lexer;
 use Allocine\TwigLinter\Ruleset\Official;
 use Allocine\TwigLinter\Validator\Validator;
 
+/**
+ * Twigcs' main functional tests
+ *
+ * @author Tristan Maindron <tmaindron@gmail.com>
+ */
 class FunctionalTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -17,7 +22,6 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
         $twig->setLexer(new Lexer($twig));
 
         $validator = new Validator();
-
 
         $violations = $validator->validate(new Official(), $twig->tokenize($expression));
 
@@ -105,6 +109,11 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
             ['{{ 1 ? "foo": "bar" }}', 'There should be 1 space(s) before ":".'],
             ['{{ 1 ? "foo" :"bar" }}', 'There should be 1 space(s) after ":".'],
             ['{{ 1 ?: "foo" }}', null],
+            ['{{ test ? { foo: bar } : 1 }}', null],
+            ['{{ test ? 1 }}', null],
+            ['{{ {foo: test ? path({bar: baz}) : null} }}', null],
+            ['{{ [test ? path({bar: baz}) : null] }}', null],
+            ['{{ { prop1: foo ? "bar", prop2: true } }}', null],
 
             // Use lower cased and underscored variable names.
             ['{% set foo = 1 %}{{ foo }}', null],
@@ -119,6 +128,9 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
             ['{% import "foo.html.twig" as foo %}', 'Unused macro "foo".'],
             ['{% import "foo.html.twig" as foo, bar %}{{ foo() ~ bar() }}', null],
             ['{% import "foo.html.twig" as foo, bar %}{{ foo() }}', 'Unused macro "bar".'],
+
+            // Complex encountered cases
+            ['{% set baz = foo is defined ? object.property : default %}{{ baz }}', null],
 
             // @TODO: Not in spec : one space separated arguments
             // @TODO: Indent your code inside tags (use the same indentation as the one used for the target language of the rendered template):


### PR DESCRIPTION
This fixes a complex interference between hashes and ternaries. Because both syntaxes uses the `:` punctuation, there was weird behaviors on hashes having ternaries inside them.

A split of the ArraySpacingRule was needed in order to have a more specific handling of hashes.
