### PR TITLE
Fixed invalid file property in checkstyle reporter

### DIFF
--- a/src/Allocine/TwigLinter/Reporter/CheckstyleReporter.php
+++ b/src/Allocine/TwigLinter/Reporter/CheckstyleReporter.php
@@ -20,7 +20,7 @@ class CheckstyleReporter implements ReporterInterface
             if ($filename != $violation->getFilename()) {
                 $filename = $violation->getFilename();
                 $filenode = $checkstyle->addChild('file');
-                $filenode->addAttribute('path', $filename);
+                $filenode->addAttribute('name', $filename);
             }
 
             $error = $filenode->addChild('error');


### PR DESCRIPTION
The `name` property was mistakenly written `path`.
