### PR TITLE
Modified the path to read autoload.php.

### DIFF
--- a/bin/twigcs
+++ b/bin/twigcs
@@ -4,6 +4,10 @@
 use Allocine\TwigLinter\Console\Application;
 use Allocine\TwigLinter\LintCommand;
 
-require 'vendor/autoload.php';
+if (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require_once __DIR__ . '/../../../autoload.php';
+} else {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}
 
 (new Application())->run();


### PR DESCRIPTION
The following error occurred using the twigcs in my environment.

```
PHP Warning:  require(vendor/autoload.php): failed to open stream: No such file or directory in /path/to/.composer/vendor/allocine/twigcs/bin/twigcs on line 7
PHP Stack trace:
PHP   1. {main}() /path/to/.composer/vendor/allocine/twigcs/bin/twigcs:0
PHP Fatal error:  require(): Failed opening required 'vendor/autoload.php' (include_path='.:/usr/share/pear:/usr/share/php') in /path/to/.composer/vendor/allocine/twigcs/bin/twigcs on line 7
PHP Stack trace:
PHP   1. {main}() /path/to/.composer/vendor/allocine/twigcs/bin/twigcs:0
```

This pull requests is, to resolve the above error.
