### PR TITLE
Brutal upgrade to twig 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "twig/twig": "~1.0",
+        "twig/twig": "~2.0",
         "symfony/console": "~2.7|~3.0",
         "symfony/finder": "~2.7|~3.0",
         "pimple/pimple": "~3.0"

--- a/src/Allocine/TwigLinter/Compatibility/TwigLexer.php
+++ b/src/Allocine/TwigLinter/Compatibility/TwigLexer.php
@@ -1,0 +1,403 @@
+<?php
+
+/*
+ * Since Twig 2.0 the Lexer API has moved from protected to private access.
+ * This class is a copy of the Twig 2.0 lexer but private were changed back to
+ * protected so twigcs can continue to work.
+ *
+ * Twigcs' overrides are located in Allocine\TwigLinter\Lexer
+ */
+
+namespace Allocine\TwigLinter\Compatibility;
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ * (c) 2009 Armin Ronacher
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Lexes a template string.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TwigLexer extends \Twig_Lexer
+{
+    protected $tokens;
+    protected $code;
+    protected $cursor;
+    protected $lineno;
+    protected $end;
+    protected $state;
+    protected $states;
+    protected $brackets;
+    protected $env;
+    protected $source;
+    protected $options;
+    protected $regexes;
+    protected $position;
+    protected $positions;
+    protected $currentVarBlockLine;
+
+    const STATE_DATA = 0;
+    const STATE_BLOCK = 1;
+    const STATE_VAR = 2;
+    const STATE_STRING = 3;
+    const STATE_INTERPOLATION = 4;
+
+    const REGEX_NAME = '/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/A';
+    const REGEX_NUMBER = '/[0-9]+(?:\.[0-9]+)?/A';
+    const REGEX_STRING = '/"([^#"\\\\]*(?:\\\\.[^#"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\'/As';
+    const REGEX_DQ_STRING_DELIM = '/"/A';
+    const REGEX_DQ_STRING_PART = '/[^#"\\\\]*(?:(?:\\\\.|#(?!\{))[^#"\\\\]*)*/As';
+    const PUNCTUATION = '()[]{}?:.,|';
+
+    public function __construct(\Twig_Environment $env, array $options = array())
+    {
+        $this->env = $env;
+
+        $this->options = array_merge(array(
+            'tag_comment' => array('{#', '#}'),
+            'tag_block' => array('{%', '%}'),
+            'tag_variable' => array('{{', '}}'),
+            'whitespace_trim' => '-',
+            'interpolation' => array('#{', '}'),
+        ), $options);
+
+        $this->regexes = array(
+            'lex_var' => '/\s*'.preg_quote($this->options['whitespace_trim'].$this->options['tag_variable'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_variable'][1], '/').'/A',
+            'lex_block' => '/\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')\n?/A',
+            'lex_raw_data' => '/('.preg_quote($this->options['tag_block'][0].$this->options['whitespace_trim'], '/').'|'.preg_quote($this->options['tag_block'][0], '/').')\s*(?:endverbatim)\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')/s',
+            'operator' => $this->getOperatorRegex(),
+            'lex_comment' => '/(?:'.preg_quote($this->options['whitespace_trim'], '/').preg_quote($this->options['tag_comment'][1], '/').'\s*|'.preg_quote($this->options['tag_comment'][1], '/').')\n?/s',
+            'lex_block_raw' => '/\s*verbatim\s*(?:'.preg_quote($this->options['whitespace_trim'].$this->options['tag_block'][1], '/').'\s*|\s*'.preg_quote($this->options['tag_block'][1], '/').')/As',
+            'lex_block_line' => '/\s*line\s+(\d+)\s*'.preg_quote($this->options['tag_block'][1], '/').'/As',
+            'lex_tokens_start' => '/('.preg_quote($this->options['tag_variable'][0], '/').'|'.preg_quote($this->options['tag_block'][0], '/').'|'.preg_quote($this->options['tag_comment'][0], '/').')('.preg_quote($this->options['whitespace_trim'], '/').')?/s',
+            'interpolation_start' => '/'.preg_quote($this->options['interpolation'][0], '/').'\s*/A',
+            'interpolation_end' => '/\s*'.preg_quote($this->options['interpolation'][1], '/').'/A',
+        );
+    }
+
+    public function tokenize(\Twig_Source $source)
+    {
+        $this->source = $source;
+        $this->code = str_replace(array("\r\n", "\r"), "\n", $source->getCode());
+        $this->cursor = 0;
+        $this->lineno = 1;
+        $this->end = strlen($this->code);
+        $this->tokens = array();
+        $this->state = self::STATE_DATA;
+        $this->states = array();
+        $this->brackets = array();
+        $this->position = -1;
+
+        // find all token starts in one go
+        preg_match_all($this->regexes['lex_tokens_start'], $this->code, $matches, PREG_OFFSET_CAPTURE);
+        $this->positions = $matches;
+
+        while ($this->cursor < $this->end) {
+            // dispatch to the lexing functions depending
+            // on the current state
+            switch ($this->state) {
+                case self::STATE_DATA:
+                    $this->lexData();
+                    break;
+
+                case self::STATE_BLOCK:
+                    $this->lexBlock();
+                    break;
+
+                case self::STATE_VAR:
+                    $this->lexVar();
+                    break;
+
+                case self::STATE_STRING:
+                    $this->lexString();
+                    break;
+
+                case self::STATE_INTERPOLATION:
+                    $this->lexInterpolation();
+                    break;
+            }
+        }
+
+        $this->pushToken(\Twig_Token::EOF_TYPE);
+
+        if (!empty($this->brackets)) {
+            list($expect, $lineno) = array_pop($this->brackets);
+            throw new Twig_Error_Syntax(sprintf('Unclosed "%s".', $expect), $lineno, $this->source);
+        }
+
+        return new \Twig_TokenStream($this->tokens, $this->source);
+    }
+
+    protected function lexData()
+    {
+        // if no matches are left we return the rest of the template as simple text token
+        if ($this->position == count($this->positions[0]) - 1) {
+            $this->pushToken(\Twig_Token::TEXT_TYPE, substr($this->code, $this->cursor));
+            $this->cursor = $this->end;
+
+            return;
+        }
+
+        // Find the first token after the current cursor
+        $position = $this->positions[0][++$this->position];
+        while ($position[1] < $this->cursor) {
+            if ($this->position == count($this->positions[0]) - 1) {
+                return;
+            }
+            $position = $this->positions[0][++$this->position];
+        }
+
+        // push the template text first
+        $text = $textContent = substr($this->code, $this->cursor, $position[1] - $this->cursor);
+        if (isset($this->positions[2][$this->position][0])) {
+            $text = rtrim($text);
+        }
+        $this->pushToken(\Twig_Token::TEXT_TYPE, $text);
+        $this->moveCursor($textContent.$position[0]);
+
+        switch ($this->positions[1][$this->position][0]) {
+            case $this->options['tag_comment'][0]:
+                $this->lexComment();
+                break;
+
+            case $this->options['tag_block'][0]:
+                // raw data?
+                if (preg_match($this->regexes['lex_block_raw'], $this->code, $match, null, $this->cursor)) {
+                    $this->moveCursor($match[0]);
+                    $this->lexRawData();
+                // {% line \d+ %}
+                } elseif (preg_match($this->regexes['lex_block_line'], $this->code, $match, null, $this->cursor)) {
+                    $this->moveCursor($match[0]);
+                    $this->lineno = (int) $match[1];
+                } else {
+                    $this->pushToken(\Twig_Token::BLOCK_START_TYPE);
+                    $this->pushState(self::STATE_BLOCK);
+                    $this->currentVarBlockLine = $this->lineno;
+                }
+                break;
+
+            case $this->options['tag_variable'][0]:
+                $this->pushToken(\Twig_Token::VAR_START_TYPE);
+                $this->pushState(self::STATE_VAR);
+                $this->currentVarBlockLine = $this->lineno;
+                break;
+        }
+    }
+
+    protected function lexBlock()
+    {
+        if (empty($this->brackets) && preg_match($this->regexes['lex_block'], $this->code, $match, null, $this->cursor)) {
+            $this->pushToken(\Twig_Token::BLOCK_END_TYPE);
+            $this->moveCursor($match[0]);
+            $this->popState();
+        } else {
+            $this->lexExpression();
+        }
+    }
+
+    protected function lexVar()
+    {
+        if (empty($this->brackets) && preg_match($this->regexes['lex_var'], $this->code, $match, null, $this->cursor)) {
+            $this->pushToken(\Twig_Token::VAR_END_TYPE);
+            $this->moveCursor($match[0]);
+            $this->popState();
+        } else {
+            $this->lexExpression();
+        }
+    }
+
+    protected function lexExpression()
+    {
+        // whitespace
+        if (preg_match('/\s+/A', $this->code, $match, null, $this->cursor)) {
+            $this->moveCursor($match[0]);
+
+            if ($this->cursor >= $this->end) {
+                throw new Twig_Error_Syntax(sprintf('Unclosed "%s".', $this->state === self::STATE_BLOCK ? 'block' : 'variable'), $this->currentVarBlockLine, $this->source);
+            }
+        }
+
+        // operators
+        if (preg_match($this->regexes['operator'], $this->code, $match, null, $this->cursor)) {
+            $this->pushToken(\Twig_Token::OPERATOR_TYPE, preg_replace('/\s+/', ' ', $match[0]));
+            $this->moveCursor($match[0]);
+        }
+        // names
+        elseif (preg_match(self::REGEX_NAME, $this->code, $match, null, $this->cursor)) {
+            $this->pushToken(\Twig_Token::NAME_TYPE, $match[0]);
+            $this->moveCursor($match[0]);
+        }
+        // numbers
+        elseif (preg_match(self::REGEX_NUMBER, $this->code, $match, null, $this->cursor)) {
+            $number = (float) $match[0];  // floats
+            if (ctype_digit($match[0]) && $number <= PHP_INT_MAX) {
+                $number = (int) $match[0]; // integers lower than the maximum
+            }
+            $this->pushToken(\Twig_Token::NUMBER_TYPE, $number);
+            $this->moveCursor($match[0]);
+        }
+        // punctuation
+        elseif (false !== strpos(self::PUNCTUATION, $this->code[$this->cursor])) {
+            // opening bracket
+            if (false !== strpos('([{', $this->code[$this->cursor])) {
+                $this->brackets[] = array($this->code[$this->cursor], $this->lineno);
+            }
+            // closing bracket
+            elseif (false !== strpos(')]}', $this->code[$this->cursor])) {
+                if (empty($this->brackets)) {
+                    throw new Twig_Error_Syntax(sprintf('Unexpected "%s".', $this->code[$this->cursor]), $this->lineno, $this->source);
+                }
+
+                list($expect, $lineno) = array_pop($this->brackets);
+                if ($this->code[$this->cursor] != strtr($expect, '([{', ')]}')) {
+                    throw new Twig_Error_Syntax(sprintf('Unclosed "%s".', $expect), $lineno, $this->source);
+                }
+            }
+
+            $this->pushToken(\Twig_Token::PUNCTUATION_TYPE, $this->code[$this->cursor]);
+            ++$this->cursor;
+        }
+        // strings
+        elseif (preg_match(self::REGEX_STRING, $this->code, $match, null, $this->cursor)) {
+            $this->pushToken(\Twig_Token::STRING_TYPE, stripcslashes(substr($match[0], 1, -1)));
+            $this->moveCursor($match[0]);
+        }
+        // opening double quoted string
+        elseif (preg_match(self::REGEX_DQ_STRING_DELIM, $this->code, $match, null, $this->cursor)) {
+            $this->brackets[] = array('"', $this->lineno);
+            $this->pushState(self::STATE_STRING);
+            $this->moveCursor($match[0]);
+        }
+        // unlexable
+        else {
+            throw new Twig_Error_Syntax(sprintf('Unexpected character "%s".', $this->code[$this->cursor]), $this->lineno, $this->source);
+        }
+    }
+
+    protected function lexRawData()
+    {
+        if (!preg_match($this->regexes['lex_raw_data'], $this->code, $match, PREG_OFFSET_CAPTURE, $this->cursor)) {
+            throw new Twig_Error_Syntax('Unexpected end of file: Unclosed "verbatim" block.', $this->lineno, $this->source);
+        }
+
+        $text = substr($this->code, $this->cursor, $match[0][1] - $this->cursor);
+        $this->moveCursor($text.$match[0][0]);
+
+        if (false !== strpos($match[1][0], $this->options['whitespace_trim'])) {
+            $text = rtrim($text);
+        }
+
+        $this->pushToken(\Twig_Token::TEXT_TYPE, $text);
+    }
+
+    protected function lexComment()
+    {
+        if (!preg_match($this->regexes['lex_comment'], $this->code, $match, PREG_OFFSET_CAPTURE, $this->cursor)) {
+            throw new Twig_Error_Syntax('Unclosed comment.', $this->lineno, $this->source);
+        }
+
+        $this->moveCursor(substr($this->code, $this->cursor, $match[0][1] - $this->cursor).$match[0][0]);
+    }
+
+    protected function lexString()
+    {
+        if (preg_match($this->regexes['interpolation_start'], $this->code, $match, null, $this->cursor)) {
+            $this->brackets[] = array($this->options['interpolation'][0], $this->lineno);
+            $this->pushToken(\Twig_Token::INTERPOLATION_START_TYPE);
+            $this->moveCursor($match[0]);
+            $this->pushState(self::STATE_INTERPOLATION);
+        } elseif (preg_match(self::REGEX_DQ_STRING_PART, $this->code, $match, null, $this->cursor) && strlen($match[0]) > 0) {
+            $this->pushToken(\Twig_Token::STRING_TYPE, stripcslashes($match[0]));
+            $this->moveCursor($match[0]);
+        } elseif (preg_match(self::REGEX_DQ_STRING_DELIM, $this->code, $match, null, $this->cursor)) {
+            list($expect, $lineno) = array_pop($this->brackets);
+            if ($this->code[$this->cursor] != '"') {
+                throw new Twig_Error_Syntax(sprintf('Unclosed "%s".', $expect), $lineno, $this->source);
+            }
+
+            $this->popState();
+            ++$this->cursor;
+        }
+    }
+
+    protected function lexInterpolation()
+    {
+        $bracket = end($this->brackets);
+        if ($this->options['interpolation'][0] === $bracket[0] && preg_match($this->regexes['interpolation_end'], $this->code, $match, null, $this->cursor)) {
+            array_pop($this->brackets);
+            $this->pushToken(\Twig_Token::INTERPOLATION_END_TYPE);
+            $this->moveCursor($match[0]);
+            $this->popState();
+        } else {
+            $this->lexExpression();
+        }
+    }
+
+    protected function pushToken($type, $value = '')
+    {
+        // do not push empty text tokens
+        if (\Twig_Token::TEXT_TYPE === $type && '' === $value) {
+            return;
+        }
+
+        $this->tokens[] = new \Twig_Token($type, $value, $this->lineno);
+    }
+
+    protected function moveCursor($text)
+    {
+        $this->cursor += strlen($text);
+        $this->lineno += substr_count($text, "\n");
+    }
+
+    protected function getOperatorRegex()
+    {
+        $operators = array_merge(
+            array('='),
+            array_keys($this->env->getUnaryOperators()),
+            array_keys($this->env->getBinaryOperators())
+        );
+
+        $operators = array_combine($operators, array_map('strlen', $operators));
+        arsort($operators);
+
+        $regex = array();
+        foreach ($operators as $operator => $length) {
+            // an operator that ends with a character must be followed by
+            // a whitespace or a parenthesis
+            if (ctype_alpha($operator[$length - 1])) {
+                $r = preg_quote($operator, '/').'(?=[\s()])';
+            } else {
+                $r = preg_quote($operator, '/');
+            }
+
+            // an operator with a space can be any amount of whitespaces
+            $r = preg_replace('/\s+/', '\s+', $r);
+
+            $regex[] = $r;
+        }
+
+        return '/'.implode('|', $regex).'/A';
+    }
+
+    protected function pushState($state)
+    {
+        $this->states[] = $this->state;
+        $this->state = $state;
+    }
+
+    protected function popState()
+    {
+        if (0 === count($this->states)) {
+            throw new LogicException('Cannot pop state without a previous state.');
+        }
+
+        $this->state = array_pop($this->states);
+    }
+}

--- a/src/Allocine/TwigLinter/Lexer.php
+++ b/src/Allocine/TwigLinter/Lexer.php
@@ -2,13 +2,15 @@
 
 namespace Allocine\TwigLinter;
 
+use Allocine\TwigLinter\Compatibility\TwigLexer;
+
 /**
  * An override of Twig's Lexer to add whitespace and new line detection.
  * It also populates a column number property on tokens.
  *
  * @author Tristan Maindron <tmaindron@gmail.com>
  */
-class Lexer extends \Twig_Lexer
+class Lexer extends TwigLexer
 {
     const PREVIOUS_TOKEN = -1;
     const NEXT_TOKEN     = 1;
@@ -75,7 +77,7 @@ class Lexer extends \Twig_Lexer
     protected function pushToken($type, $value = '')
     {
         // do not push empty text tokens
-        if (Token::TEXT_TYPE === $type && '' === $value) {
+        if (\Twig_Token::TEXT_TYPE === $type && '' === $value) {
             return;
         }
 
@@ -84,7 +86,13 @@ class Lexer extends \Twig_Lexer
             $this->columnno++;
         }
 
-        $this->tokens[] = new Token($type, $value, $this->lineno, $this->columnno);
+        $token = new \Twig_Token($type, $value, $this->lineno);
+
+        // Twig tokens cannot be extended anymore since 2.0, so a dynamic attribute
+        // is the only way to store the column number.
+        $token->columnno = $this->columnno;
+
+        $this->tokens[] = $token;
     }
 
     /**

--- a/src/Allocine/TwigLinter/Reporter/CheckstyleReporter.php
+++ b/src/Allocine/TwigLinter/Reporter/CheckstyleReporter.php
@@ -29,7 +29,6 @@ class CheckstyleReporter implements ReporterInterface
             $error->addAttribute('severity', strtolower($violation->getSeverityAsString()));
             $error->addAttribute('message', $violation->getReason());
             $error->addAttribute('source', $violation->getSource());
-
         }
 
         $output->writeln($checkstyle->asXML());

--- a/src/Allocine/TwigLinter/Reporter/ConsoleReporter.php
+++ b/src/Allocine/TwigLinter/Reporter/ConsoleReporter.php
@@ -22,7 +22,7 @@ class ConsoleReporter implements ReporterInterface
             $output->writeln(sprintf(
                 '<comment>l.%d c.%d</comment> : %s %s',
                 $violation->getLine(),
-                $violation->getColumn(),
+                $violation->columnno,
                 $violation->getSeverityAsString(),
                 $violation->getReason()
             ));

--- a/src/Allocine/TwigLinter/Rule/AbstractSpacingRule.php
+++ b/src/Allocine/TwigLinter/Rule/AbstractSpacingRule.php
@@ -49,18 +49,18 @@ class AbstractSpacingRule extends AbstractRule
         if ($spacing === 0) {
             if ($token->getType() === Token::WHITESPACE_TYPE) {
                 $this->addViolation(
-                    $tokens->getFilename(),
+                    $tokens->getSourceContext()->getPath(),
                     $current->getLine(),
-                    $current->getColumn(),
+                    $current->columnno,
                     sprintf('There should be no space %s "%s".', $positionName, $current->getValue())
                 );
             }
 
             if ($token->getType() === Token::NEWLINE_TYPE) {
                 $this->addViolation(
-                    $tokens->getFilename(),
+                    $tokens->getSourceContext()->getPath(),
                     $current->getLine(),
-                    $current->getColumn(),
+                    $current->columnno,
                     sprintf('There should be no new line %s "%s".', $positionName, $current->getValue())
                 );
             }
@@ -70,18 +70,18 @@ class AbstractSpacingRule extends AbstractRule
 
         if ($token->getType() !== Token::WHITESPACE_TYPE || strlen($token->getValue()) < $spacing) {
             $this->addViolation(
-                $tokens->getFilename(),
+                $tokens->getSourceContext()->getPath(),
                 $current->getLine(),
-                $current->getColumn(),
+                $current->columnno,
                 sprintf('There should be %d space(s) %s "%s".', $spacing, $positionName, $current->getValue())
             );
         }
 
         if ($token->getType() === Token::WHITESPACE_TYPE && strlen($token->getValue()) > $spacing) {
             $this->addViolation(
-                $tokens->getFilename(),
+                $tokens->getSourceContext()->getPath(),
                 $current->getLine(),
-                $current->getColumn(),
+                $current->columnno,
                 sprintf('More than %d space(s) found %s "%s".', $spacing, $positionName, $current->getValue())
             );
         }

--- a/src/Allocine/TwigLinter/Rule/DelimiterSpacing.php
+++ b/src/Allocine/TwigLinter/Rule/DelimiterSpacing.php
@@ -60,18 +60,18 @@ class DelimiterSpacing extends AbstractRule implements RuleInterface
 
         if ($token->getType() !== Token::WHITESPACE_TYPE || strlen($token->getValue()) < $this->spacing) {
             $this->addViolation(
-                $tokens->getFilename(),
+                $tokens->getSourceContext()->getPath(),
                 $token->getLine(),
-                $token->getColumn(),
+                $token->columnno,
                 sprintf('There should be %d space(s) %s.', $this->spacing, $target)
             );
         }
 
         if ($token->getType() === Token::WHITESPACE_TYPE && strlen($token->getValue()) > $this->spacing) {
             $this->addViolation(
-                $tokens->getFilename(),
+                $tokens->getSourceContext()->getPath(),
                 $token->getLine(),
-                $token->getColumn(),
+                $token->columnno,
                 sprintf('More than %d space(s) found %s.', $this->spacing, $target)
             );
         }

--- a/src/Allocine/TwigLinter/Rule/HashSeparatorSpacing.php
+++ b/src/Allocine/TwigLinter/Rule/HashSeparatorSpacing.php
@@ -78,7 +78,7 @@ class HashSeparatorSpacing extends AbstractSpacingRule implements RuleInterface
                 $this->assertSpacing($tokens, Lexer::PREVIOUS_TOKEN, $this->spaceBefore, false);
             }
 
-            if ($arrayDepth > 0 && in_array($this->getPreviousSignicantToken($tokens)->getType(), [Token::NAME_TYPE, Token::STRING_TYPE])) {
+            if ($arrayDepth > 0 && in_array($this->getPreviousSignicantToken($tokens)->getType(), [\Twig_Token::NAME_TYPE, \Twig_Token::STRING_TYPE])) {
                 if (!$skip && $token->getType() === \Twig_Token::PUNCTUATION_TYPE && $token->getValue() === ':') {
                     $this->assertSpacing($tokens, Lexer::NEXT_TOKEN, $this->spaceAfter);
                     $this->assertSpacing($tokens, Lexer::PREVIOUS_TOKEN, $this->spaceBefore, false);

--- a/src/Allocine/TwigLinter/Rule/LowerCaseVariable.php
+++ b/src/Allocine/TwigLinter/Rule/LowerCaseVariable.php
@@ -20,7 +20,7 @@ class LowerCaseVariable extends AbstractRule implements RuleInterface
 
             if ($token->getType() === \Twig_Token::NAME_TYPE && preg_match('/[A-Z]/', $token->getValue())) {
                 if ($tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Token::WHITESPACE_TYPE && $tokens->look(-2)->getValue() === 'set') {
-                    $this->addViolation($tokens->getFilename(), $token->getLine(), $token->getColumn(), sprintf('The "%s" variable should be in lower case (use _ as a separator).', $token->getValue()));
+                    $this->addViolation($tokens->getSourceContext()->getPath(), $token->getLine(), $token->columnno, sprintf('The "%s" variable should be in lower case (use _ as a separator).', $token->getValue()));
                 }
             }
 

--- a/src/Allocine/TwigLinter/Rule/TrailingSpace.php
+++ b/src/Allocine/TwigLinter/Rule/TrailingSpace.php
@@ -23,13 +23,13 @@ class TrailingSpace extends AbstractRule implements RuleInterface
             $token = $tokens->getCurrent();
 
             if ($token->getType() === Token::NEWLINE_TYPE && $tokens->look(-1)->getType() === Token::WHITESPACE_TYPE ||
-                $token->getType() === Token::TEXT_TYPE
+                $token->getType() === \Twig_Token::TEXT_TYPE
             ) {
                 if (preg_match("/[[:blank:]]+\n/", $token->getValue())) {
                     $this->addViolation(
-                        $tokens->getFilename(),
+                        $tokens->getSourceContext()->getPath(),
                         $token->getLine(),
-                        $token->getColumn(),
+                        $token->columnno,
                         'A line should not end with blank space(s).'
                     );
                 }

--- a/src/Allocine/TwigLinter/Rule/UnusedMacro.php
+++ b/src/Allocine/TwigLinter/Rule/UnusedMacro.php
@@ -43,9 +43,9 @@ class UnusedMacro extends AbstractRule implements RuleInterface
 
         foreach ($macros as $name => $originalToken) {
             $this->addViolation(
-                $tokens->getFilename(),
+                $tokens->getSourceContext()->getPath(),
                 $originalToken->getLine(),
-                $originalToken->getColumn(),
+                $originalToken->columnno,
                 sprintf('Unused macro "%s".', $name)
             );
         }

--- a/src/Allocine/TwigLinter/Rule/UnusedVariable.php
+++ b/src/Allocine/TwigLinter/Rule/UnusedVariable.php
@@ -32,9 +32,9 @@ class UnusedVariable extends AbstractRule implements RuleInterface
 
         foreach ($variables as $name => $originalToken) {
             $this->addViolation(
-                $tokens->getFilename(),
+                $tokens->getSourceContext()->getPath(),
                 $originalToken->getLine(),
-                $originalToken->getColumn(),
+                $originalToken->columnno,
                 sprintf('Unused variable "%s".', $name)
             );
         }

--- a/src/Allocine/TwigLinter/Tests/FunctionalTest.php
+++ b/src/Allocine/TwigLinter/Tests/FunctionalTest.php
@@ -18,12 +18,12 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpressions($expression, $expectedViolation)
     {
-        $twig = new \Twig_Environment();
+        $twig = new \Twig_Environment(new \Twig_Loader_Array());
         $twig->setLexer(new Lexer($twig));
 
         $validator = new Validator();
 
-        $violations = $validator->validate(new Official(), $twig->tokenize($expression));
+        $violations = $validator->validate(new Official(), $twig->tokenize(new \Twig_Source($expression, 'src', 'src.html.twig')));
 
         if ($expectedViolation) {
             $this->assertSame(1, count($violations));

--- a/src/Allocine/TwigLinter/Token.php
+++ b/src/Allocine/TwigLinter/Token.php
@@ -2,36 +2,10 @@
 
 namespace Allocine\TwigLinter;
 
-class Token extends \Twig_Token
+class Token
 {
     const WHITESPACE_TYPE = 12;
     const NEWLINE_TYPE    = 13;
-
-    /**
-     * @var int
-     */
-    private $columnno;
-
-    /**
-     * @param int    $type
-     * @param string $value
-     * @param int    $lineno
-     * @param int    $columnno
-     */
-    public function __construct($type, $value, $lineno, $columnno)
-    {
-        parent::__construct($type, $value, $lineno);
-
-        $this->columnno = $columnno;
-    }
-
-    /**
-     * @return int
-     */
-    public function getColumn()
-    {
-        return $this->columnno;
-    }
 
     /**
      * @param string  $type


### PR DESCRIPTION
The master branch will now only support twig 2.0. A `1.0.0` version was tagged that still uses Twig 1.x. Also, a `1.x` branch was created for bugfixes. 

After this merge, a 2.0.0 version of twigcs will be tagged.

This PR introduces huge changes as the main feature of twig 2.0 is to close their API. I couldn't avoid to copy the base lexer in order to override some parts of it.

Also, the `Twig_Token` class is now locked with a `final` and cannot be extended. So the only solution to quickly upgrade was to remove the inheritance of our custom token. The column number feature still works but is now a dynamic attribute instead of a getter.

I hope we will figure out how to make things cleaner in the future.