### PR TITLE
Fix undefined columnno attribute on ConsoleReporter

### DIFF
--- a/src/Allocine/TwigLinter/Reporter/ConsoleReporter.php
+++ b/src/Allocine/TwigLinter/Reporter/ConsoleReporter.php
@@ -29,7 +29,7 @@ class ConsoleReporter implements ReporterInterface
         }
 
         if ($count = count($violations)) {
-            $output->writeln(sprintf('<error>%d violations found</error>', $count));
+            $output->writeln(sprintf('<error>%d violation(s) found</error>', $count));
         } else {
             $output->writeln('<info>No violation found.</info>');
         }

--- a/src/Allocine/TwigLinter/Reporter/ConsoleReporter.php
+++ b/src/Allocine/TwigLinter/Reporter/ConsoleReporter.php
@@ -22,7 +22,7 @@ class ConsoleReporter implements ReporterInterface
             $output->writeln(sprintf(
                 '<comment>l.%d c.%d</comment> : %s %s',
                 $violation->getLine(),
-                $violation->columnno,
+                $violation->getColumn(),
                 $violation->getSeverityAsString(),
                 $violation->getReason()
             ));

--- a/src/Allocine/TwigLinter/Tests/Reporter/CheckstyleReporterTest.php
+++ b/src/Allocine/TwigLinter/Tests/Reporter/CheckstyleReporterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Allocine\TwigLinter\Tests\Reporter;
+
+use Allocine\TwigLinter\Reporter\CheckstyleReporter;
+use Allocine\TwigLinter\Validator\Violation;
+
+class CheckstyleReporterTest extends \PHPUnit_Framework_TestCase
+{
+    const EXPECTED_REPORT = <<<EOF
+<?xml version="1.0"?>
+<checkstyle version="1.0.0"><file name="template.twig"><error column="20" line="10" severity="error" message="You are not allowed to do that." source="unknown"/></file></checkstyle>
+
+EOF;
+
+    public function testReport()
+    {
+        $reporter = new CheckstyleReporter();
+        $output = $this
+            ->getMockBuilder('Symfony\Component\Console\Output\ConsoleOutput')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $output
+            ->expects($this->once())
+            ->method('writeln')
+            ->with(self::EXPECTED_REPORT)
+        ;
+
+        $reporter->report($output, [
+            new Violation('template.twig', 10, 20, 'You are not allowed to do that.')
+        ]);
+    }
+}

--- a/src/Allocine/TwigLinter/Tests/Reporter/ConsoleReporterTest.php
+++ b/src/Allocine/TwigLinter/Tests/Reporter/ConsoleReporterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Allocine\TwigLinter\Tests\Reporter;
+
+use Allocine\TwigLinter\Reporter\ConsoleReporter;
+use Allocine\TwigLinter\Validator\Violation;
+
+class ConsoleReporterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReport()
+    {
+        $reporter = new ConsoleReporter();
+        $output = $this
+            ->getMockBuilder('Symfony\Component\Console\Output\ConsoleOutput')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $output
+            ->expects($this->at(1))
+            ->method('writeln')
+            ->with('<comment>l.10 c.20</comment> : ERROR You are not allowed to do that.')
+        ;
+
+        $output
+            ->expects($this->at(2))
+            ->method('writeln')
+            ->with('<error>1 violation(s) found</error>')
+        ;
+
+        $reporter->report($output, [
+            new Violation('template.twig', 10, 20, 'You are not allowed to do that.')
+        ]);
+    }
+}


### PR DESCRIPTION
This fixes a mistake during the twig 2.0 upgrade and also adds tests to ensure this won't happen again.