### PR TITLE
Allow whitespace before closing parenthesis in multiline calls

### DIFF
--- a/src/Allocine/TwigLinter/Rule/ParenthesisSpacing.php
+++ b/src/Allocine/TwigLinter/Rule/ParenthesisSpacing.php
@@ -64,7 +64,7 @@ class ParenthesisSpacing extends AbstractSpacingRule implements RuleInterface
             }
 
             if ($token->getValue() === ')' && $token->getType() === \Twig_Token::PUNCTUATION_TYPE && $tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Token::WHITESPACE_TYPE) {
-                $this->assertSpacing($tokens, Lexer::PREVIOUS_TOKEN, $this->spacing);
+                $this->assertSpacing($tokens, Lexer::PREVIOUS_TOKEN, $this->spacing, true, true);
             }
 
             $tokens->next();

--- a/src/Allocine/TwigLinter/Tests/FunctionalTest.php
+++ b/src/Allocine/TwigLinter/Tests/FunctionalTest.php
@@ -139,6 +139,9 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
             // Complex encountered cases
             ['{% set baz = foo is defined ? object.property : default %}{{ baz }}', null],
 
+            // Wrapped call for better readability
+            ["\t<meta property=\"og:url\" content=\"{{ url(\n\t\tapp.request.attributes.get('_route'),\n\t\tapp.request.attributes.get('_route_params')\n\t) }}\">", null],
+
             // Spaces
             ["{{ foo }}    \n", "A line should not end with blank space(s)."],
             ["{{ foo }}\t\n", "A line should not end with blank space(s)."],

--- a/src/Allocine/TwigLinter/Tests/FunctionalTest.php
+++ b/src/Allocine/TwigLinter/Tests/FunctionalTest.php
@@ -26,10 +26,10 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
         $violations = $validator->validate(new Official(), $twig->tokenize(new \Twig_Source($expression, 'src', 'src.html.twig')));
 
         if ($expectedViolation) {
-            $this->assertSame(1, count($violations));
+            $this->assertCount(1, $violations, sprintf("There should be exactly one violation in:\n %s", $expression));
             $this->assertSame($expectedViolation, $violations[0]->getReason());
         } else {
-            $this->assertSame(0, count($violations));
+            $this->assertCount(0, $violations, sprintf("There should be no violations in:\n %s", $expression));
         }
     }
 


### PR DESCRIPTION
In cases where the function call would be hard to read it makes sense to wrap the call on multiple lines like this:

```
<meta property="og:url" content="{{ url(
	app.request.attributes.get('_route'),
	app.request.attributes.get('_route_params')
) }}">
```

This patch adds a method to check if preceding whitespace is only indentation. 