### PR TITLE
Made the dependency requirements more suitable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,14 @@
         }
     ],
     "require": {
-        "php": "~7.0",
-        "twig/twig": "~2.0",
-        "symfony/console": "~2.7|~3.0",
-        "symfony/finder": "~2.7|~3.0",
-        "pimple/pimple": "~3.0"
+        "php": "^7.0",
+        "twig/twig": "^1.0 || ^2.0",
+        "symfony/console": "^2.7 || ^3.0 || ^4.0",
+        "symfony/finder": "^2.7 || ^3.0 || ^4.0",
+        "pimple/pimple": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7"
+        "phpunit/phpunit": "^4.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* With actual Twig dependency requirement, it does not possible to use the library with the Twig v1 when the library is fully compatible.