### PR TITLE
Implement twigcs as a single command application

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ composer global require allocine/twigcs
 Basically, just run :
 
 ```bash
-twigcs lint /path/to/views
+twigcs /path/to/views
 ```
 
 On Symfony projects, you can run, for instance :
 
 ```bash
-twigcs lint /project/dir/app/Resources/views
+twigcs /project/dir/app/Resources/views
 ```
 
 You will get a summary of the violations in the console. The exit code of the command is based on the severity
 of any violation found. By default, twigcs won't even tolerate a notice, this can be changed at run time :
 
 ```bash
-twigcs lint /path/to/views --severity warning # Allow notices
+twigcs /path/to/views --severity warning # Allow notices
 ```
 
 With the example above, notices are still displayed but not altering the exit code.
@@ -41,7 +41,7 @@ Twigcs can be used with your favorite CI server. The command itself will return 
 the CI job if it failed or succeeded. You can also have a nice xml report (checkstyle format) :
 
 ```bash
-twigcs lint /path/to/views --reporter checkstyle > /path/to/report.xml
+twigcs /path/to/views --reporter checkstyle > /path/to/report.xml
 ```
 
 ### Coding standard
@@ -53,7 +53,7 @@ At the moment the only available standard is the [official one from twig](http:/
 You can create a class implementing `RulesetInterface` and supply it as a `--ruleset` option to the CLI script: 
 
 ```bash
-twigcs lint /path/to/views --ruleset \MyApp\TwigCsRuleset
+twigcs /path/to/views --ruleset \MyApp\TwigCsRuleset
 ```
 
 *Note:* `twigcs` needs to be used via composer and the ruleset class must be reachable via composer's autoloader for this feature to work.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "pimple/pimple": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.7"
+        "phpunit/phpunit": "^7.2 || ^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -5,6 +5,7 @@ namespace Allocine\Twigcs\Console;
 use Allocine\Twigcs\Container;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArgvInput;
 
 class Application extends BaseApplication
 {
@@ -22,7 +23,17 @@ class Application extends BaseApplication
         parent::__construct($name, $version);
 
         $this->container = new Container();
-        $this->add(new LintCommand());
+        $command = new LintCommand();
+        $this->add($command);
+        // Support old way to execute linter (`twigcs lint <path>`) to preserve
+        // backward compatibility.
+        if ((new ArgvInput())->getFirstArgument() == 'lint') {
+            @trigger_error("Calling 'lint' command is deprecated. Run `twigs <path>` instead.", E_USER_DEPRECATED);
+        }
+        else {
+            $this->setDefaultCommand($command->getName(), true);
+        }
+
     }
 
     /**

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -5,13 +5,14 @@ namespace Allocine\Twigcs\Test;
 use Allocine\Twigcs\Lexer;
 use Allocine\Twigcs\Ruleset\Official;
 use Allocine\Twigcs\Validator\Validator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Twigcs' main functional tests
  *
  * @author Tristan Maindron <tmaindron@gmail.com>
  */
-class FunctionalTest extends \PHPUnit_Framework_TestCase
+class FunctionalTest extends TestCase
 {
     /**
      * @dataProvider getData

--- a/tests/Reporter/CheckstyleReporterTest.php
+++ b/tests/Reporter/CheckstyleReporterTest.php
@@ -4,8 +4,9 @@ namespace Allocine\Twigcs\Tests\Reporter;
 
 use Allocine\Twigcs\Reporter\CheckstyleReporter;
 use Allocine\Twigcs\Validator\Violation;
+use PHPUnit\Framework\TestCase;
 
-class CheckstyleReporterTest extends \PHPUnit_Framework_TestCase
+class CheckstyleReporterTest extends TestCase
 {
     const EXPECTED_REPORT = <<<EOF
 <?xml version="1.0"?>

--- a/tests/Reporter/ConsoleReporterTest.php
+++ b/tests/Reporter/ConsoleReporterTest.php
@@ -4,8 +4,9 @@ namespace Allocine\Twigcs\Tests\Reporter;
 
 use Allocine\Twigcs\Reporter\ConsoleReporter;
 use Allocine\Twigcs\Validator\Violation;
+use PHPUnit\Framework\TestCase;
 
-class ConsoleReporterTest extends \PHPUnit_Framework_TestCase
+class ConsoleReporterTest extends TestCase
 {
     public function testReport()
     {


### PR DESCRIPTION
_twigcs_ by its nature is a single command application. So having to call `lint` command explicitly seems redundant. 