### PR TITLE
Improved unused variables and macros detection

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -70,6 +70,19 @@ class Lexer extends TwigLexer
         }
     }
 
+    protected function lexComment()
+    {
+        if (!preg_match($this->regexes['lex_comment'], $this->code, $match, PREG_OFFSET_CAPTURE, $this->cursor)) {
+            throw new \Twig_Error_Syntax('Unclosed comment.', $this->lineno, $this->source);
+        }
+
+        $content = substr($this->code, $this->cursor, $match[0][1] - $this->cursor);
+
+        $this->pushToken(Token::COMMENT_TYPE, trim($content));
+
+        $this->moveCursor($content.$match[0][0]);
+    }
+
     /**
      * @param int    $type
      * @param string $value

--- a/src/Rule/AbstractRule.php
+++ b/src/Rule/AbstractRule.php
@@ -71,4 +71,66 @@ abstract class AbstractRule
 
         return null;
     }
+
+    /**
+     * @param \Twig_TokenStream $tokens
+     * @param integer           $skip
+     *
+     * @return null|Token
+     */
+    protected function getNextSignicantToken(\Twig_TokenStream $tokens, $skip = 0)
+    {
+        $i = 1;
+        $token = null;
+
+        while ($token = $tokens->look($i)) {
+            if (!in_array($token->getType(), [Token::WHITESPACE_TYPE, Token::NEWLINE_TYPE])) {
+                if ($skip === 0) {
+                    return $token;
+                }
+
+                $skip--;
+            }
+
+            $i++;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Twig_TokenStream $tokens
+     * @param int               $tokenType
+     */
+    protected function skipTo(\Twig_TokenStream $tokens, int $tokenType, string $tokenValue = null)
+    {
+        while (!$tokens->isEOF()) {
+            $continue = $tokens->getCurrent()->getType() !== $tokenType;
+
+            if ($tokenValue !== null) {
+                $continue |= $tokens->getCurrent()->getValue() !== $tokenValue;
+            }
+
+            if (!$continue) {
+                return;
+            }
+
+            $tokens->next();
+        }
+    }
+
+    /**
+     * @param \Twig_TokenStream $tokens
+     * @param int               $amount
+     */
+    protected function skip(\Twig_TokenStream $tokens, int $amount)
+    {
+        while (!$tokens->isEOF()) {
+            $amount--;
+            $tokens->next();
+            if ($amount === 0) {
+                return;
+            }
+        }
+    }
 }

--- a/src/Rule/UnusedMacro.php
+++ b/src/Rule/UnusedMacro.php
@@ -2,6 +2,7 @@
 
 namespace Allocine\Twigcs\Rule;
 
+use Allocine\Twigcs\Scope\Scope;
 use Allocine\Twigcs\Token;
 
 class UnusedMacro extends AbstractRule implements RuleInterface
@@ -11,48 +12,91 @@ class UnusedMacro extends AbstractRule implements RuleInterface
      */
     public function check(\Twig_TokenStream $tokens)
     {
-        $this->reset();
+        $scope = new Scope('file');
+        $root = $scope;
 
-        $macros = [];
+        $this->reset();
 
         while (!$tokens->isEOF()) {
             $token = $tokens->getCurrent();
 
-            if ($token->getType() === \Twig_Token::NAME_TYPE && $token->getValue() === 'import') {
-                if ($tokens->look(4)->getValue() == 'as') {
-                    $forward = 6; // Extracts token position from block of form {% import foo as bar %}
-                } else {
-                    $forward = 2; // Extracts token position from block of form {% import foo %}
-                }
+            if ($token->getType() === \Twig_Token::BLOCK_START_TYPE) {
+                $blockType = $tokens->look(2)->getValue();
 
-                $macroToken = $tokens->look($forward);
-
-                for ($i=0; $i<$forward; $i++) {
-                    $tokens->next();
-                }
-
-                // Handles single or multiple imports ( {% import foo as bar, baz %} )
-                while (in_array($tokens->getCurrent()->getType(), [\Twig_Token::NAME_TYPE, \Twig_Token::PUNCTUATION_TYPE, Token::WHITESPACE_TYPE])) {
-                    $next = $tokens->getCurrent();
-                    if ($next->getType() === \Twig_Token::NAME_TYPE) {
-                        $macros[$next->getValue()] = $next;
+                if (in_array($blockType, ['block', 'for', 'embed', 'macro'])) {
+                    $scope = $scope->spawn($blockType);
+                    if ($blockType === 'macro') {
+                        $scope->isolate();
                     }
-                    $tokens->next();
                 }
-            } elseif ($token->getType() === \Twig_Token::NAME_TYPE && array_key_exists($token->getValue(), $macros)) {
-                unset($macros[$token->getValue()]);
+
+                if (in_array($blockType, ['endblock', 'endfor', 'endembed', 'endmacro'])) {
+                    $scope = $scope->leave();
+                }
             }
 
-            $tokens->next();
+            if ($token->getType() === \Twig_Token::BLOCK_START_TYPE) {
+                $blockType = $tokens->look(2)->getValue();
+
+                switch ($blockType) {
+                    case 'from':
+                        if ($tokens->look(10)->getValue() == 'as') {
+                            $forward = 12; // Extracts token position from block of form {% import foo as bar %}
+                        } else {
+                            $forward = 8; // Extracts token position from block of form {% import foo %}
+                        }
+
+                        $this->skip($tokens, $forward);
+
+                        // Handles single or multiple imports ( {% from "file.twig" import foo as bar, baz %} )
+                        while (in_array($tokens->getCurrent()->getType(), [\Twig_Token::NAME_TYPE, \Twig_Token::PUNCTUATION_TYPE, Token::WHITESPACE_TYPE])) {
+                            $next = $tokens->getCurrent();
+                            if ($next->getType() === \Twig_Token::NAME_TYPE) {
+                                $scope->declare($next->getValue(), $next);
+                            }
+                            $tokens->next();
+                        }
+                        break;
+                    case 'import':
+                        $this->skipTo($tokens, \Twig_Token::NAME_TYPE, 'as');
+                        $this->skip($tokens, 2);
+
+                        // Handles single or multiple imports ( {% import foo as bar, baz %} )
+                        while (in_array($tokens->getCurrent()->getType(), [\Twig_Token::NAME_TYPE, \Twig_Token::PUNCTUATION_TYPE, Token::WHITESPACE_TYPE])) {
+                            $next = $tokens->getCurrent();
+                            if ($next->getType() === \Twig_Token::NAME_TYPE) {
+                                $scope->declare($next->getValue(), $next);
+                            }
+                            $tokens->next();
+                        }
+                        break;
+                    case 'if':
+                    case 'for':
+                        $this->skip($tokens, 3);
+                        break;
+                    default:
+                        $this->skipTo($tokens, \Twig_Token::BLOCK_END_TYPE);
+                }
+            } elseif ($token->getType() === \Twig_Token::NAME_TYPE) {
+                $previous = $this->getPreviousSignicantToken($tokens);
+                $next = $this->getNextSignicantToken($tokens);
+
+                if (!in_array($previous->getValue(), ['.', '|']) && in_array($next->getValue(), ['('])) {
+                    $scope->use($token->getValue());
+                }
+
+                $tokens->next();
+            } else {
+                $tokens->next();
+            }
         }
 
-
-        foreach ($macros as $name => $originalToken) {
+        foreach ($root->getUnused() as $declarationToken) {
             $this->addViolation(
                 $tokens->getSourceContext()->getPath(),
-                $originalToken->getLine(),
-                $originalToken->columnno,
-                sprintf('Unused macro "%s".', $name)
+                $declarationToken->getLine(),
+                $declarationToken->columnno,
+                sprintf('Unused macro import "%s".', $declarationToken->getValue())
             );
         }
 

--- a/src/Rule/UnusedVariable.php
+++ b/src/Rule/UnusedVariable.php
@@ -3,6 +3,7 @@
 namespace Allocine\Twigcs\Rule;
 
 use Allocine\Twigcs\Lexer;
+use Allocine\Twigcs\Scope\Scope;
 use Allocine\Twigcs\Token;
 
 class UnusedVariable extends AbstractRule implements RuleInterface
@@ -12,30 +13,89 @@ class UnusedVariable extends AbstractRule implements RuleInterface
      */
     public function check(\Twig_TokenStream $tokens)
     {
-        $this->reset();
+        $scope = new Scope('file');
+        $root = $scope;
 
-        $variables = [];
+        $this->reset();
 
         while (!$tokens->isEOF()) {
             $token = $tokens->getCurrent();
 
-            if ($token->getType() === \Twig_Token::NAME_TYPE) {
-                if ($tokens->look(Lexer::PREVIOUS_TOKEN)->getType() === Token::WHITESPACE_TYPE && $tokens->look(-2)->getValue() === 'set') {
-                    $variables[$token->getValue()] = $token;
-                } else {
-                    unset($variables[$token->getValue()]);
+            if ($token->getType() === \Twig_Token::BLOCK_START_TYPE) {
+                $blockType = $tokens->look(2)->getValue();
+
+                if (in_array($blockType, ['block', 'for', 'embed', 'macro'])) {
+                    $scope = $scope->spawn($blockType);
+                    if ($blockType === 'macro') {
+                        $scope->isolate();
+                    }
+                }
+
+                if (in_array($blockType, ['endblock', 'endfor', 'endembed', 'endmacro'])) {
+                    $scope = $scope->leave();
                 }
             }
 
-            $tokens->next();
+            if ($token->getType() === \Twig_Token::BLOCK_START_TYPE) {
+                $blockType = $tokens->look(2)->getValue();
+
+                switch ($blockType) {
+                    case 'from':
+                        $from = $tokens->look(4);
+
+                        if ($from->getType() === \Twig_Token::NAME_TYPE) { // {% from varName import ... %}
+                            $scope->use($from->getValue());
+                        }
+                        $this->skipTo($tokens, \Twig_Token::BLOCK_END_TYPE);
+                        break;
+                    case 'set':
+                        $scope->declare($tokens->look(4)->getValue(), $tokens->look(4));
+                        $this->skipTo($tokens, \Twig_Token::OPERATOR_TYPE, '=');
+                        break;
+                    case 'if':
+                    case 'for':
+                        $this->skip($tokens, 3);
+                        break;
+                    default:
+                        $this->skipTo($tokens, \Twig_Token::BLOCK_END_TYPE);
+                }
+            } elseif ($token->getType() === \Twig_Token::NAME_TYPE) {
+                $previous = $this->getPreviousSignicantToken($tokens);
+                $next = $this->getNextSignicantToken($tokens);
+
+                $isHashKey = in_array($previous->getValue(), [',', '{']) && $next->getValue() === ':';
+                $isFilter = $previous->getValue() === '|';
+                $isProperty = $previous->getValue() === '.';
+                $isFunctionCall = $next->getValue() === '(';
+                $isTest = ($previous->getValue() === 'is') || ($previous->getValue() === 'is not');
+                $isReserved = in_array($token->getValue(), ['null', 'true', 'false']);
+
+                if (!$isHashKey && !$isFilter && !$isProperty && !$isFunctionCall && !$isTest && !$isReserved) {
+                    $scope->use($token->getValue());
+                }
+
+                $tokens->next();
+            } elseif ($token->getType() === Token::COMMENT_TYPE) {
+                if (strpos($token->getValue(), 'twigcs use-var ') === 0) {
+                    $names = explode(',', str_replace('twigcs use-var ', '', $token->getValue()));
+
+                    foreach ($names as $name) {
+                        $scope->use(trim($name));
+                    }
+                }
+
+                $tokens->next();
+            } else {
+                $tokens->next();
+            }
         }
 
-        foreach ($variables as $name => $originalToken) {
+        foreach ($root->getUnused() as $declarationToken) {
             $this->addViolation(
                 $tokens->getSourceContext()->getPath(),
-                $originalToken->getLine(),
-                $originalToken->columnno,
-                sprintf('Unused variable "%s".', $name)
+                $declarationToken->getLine(),
+                $declarationToken->columnno,
+                sprintf('Unused variable "%s".', $declarationToken->getValue())
             );
         }
 

--- a/src/Scope/Scope.php
+++ b/src/Scope/Scope.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Allocine\Twigcs\Scope;
+
+class Scope
+{
+    /**
+     * @var array
+     */
+    private $children;
+
+    /**
+     * @var Scope|null
+     */
+    private $parent;
+
+    /**
+     * @var array
+     */
+    private $declarations;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var array
+     */
+    private $usages;
+
+    /**
+     * @var bool
+     */
+    private $isolated;
+
+    /**
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+        $this->children = [];
+        $this->declarations = [];
+        $this->usages = [];
+        $this->isolated = false;
+    }
+
+    /**
+     * When isolated, a scope won't be explored when looking for name usages.
+     */
+    public function isolate()
+    {
+        $this->isolated = true;
+    }
+
+    public function isIsolated(): bool
+    {
+        return $this->isolated;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return Scope
+     */
+    public function spawn(string $name): Scope
+    {
+        $scope = new Scope($name);
+        $scope->parent = $this;
+        $this->children[]= $scope;
+
+        return $scope;
+    }
+
+    /**
+     * @return Scope
+     */
+    public function leave(): Scope
+    {
+        return $this->parent ?? $this;
+    }
+
+    /**
+     * @param string $name
+     * @param Token  $token
+     */
+    public function declare(string $name, \Twig_Token $token)
+    {
+        $this->declarations[$name]= $token;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function use(string $name)
+    {
+        $this->usages[]= $name;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUnused(): array
+    {
+        $unused = [];
+
+        foreach ($this->declarations as $name => $token) {
+            if (!$this->isUsed($name)) {
+                $unused[]= $token;
+            }
+        }
+
+        foreach ($this->children as $child) {
+            $unused = array_merge($unused, $child->getUnused());
+        }
+
+        return $unused;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function isUsed(string $name): bool
+    {
+        if (in_array($name, $this->usages)) {
+            return true;
+        }
+
+        foreach ($this->children as $child) {
+            if (!$child->isIsolated() && $child->isUsed($name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Token.php
+++ b/src/Token.php
@@ -6,6 +6,7 @@ class Token
 {
     const WHITESPACE_TYPE = 12;
     const NEWLINE_TYPE    = 13;
+    const COMMENT_TYPE    = 14;
 
     /**
      * @param string  $type
@@ -21,6 +22,10 @@ class Token
 
         if ($type === self::NEWLINE_TYPE) {
             return $short ? 'NEWLINE_TYPE' : 'Twig_Token::NEWLINE_TYPE';
+        }
+
+        if ($type === self::COMMENT_TYPE) {
+            return $short ? 'COMMENT_TYPE' : 'Twig_Token::COMMENT_TYPE';
         }
 
         return \Twig_Token::typeToString($type, $short);


### PR DESCRIPTION
This is a quite big PR that improves a lot the handling of unused variables and macros.

- It provides a first implementation for scopes that should solve https://github.com/allocine/twigcs/issues/27
- It also do better with reserved keywords and should solve https://github.com/allocine/twigcs/issues/28.
- Last, it introduces a way to mark variables as used with a special comment : `{# twigcs use-var myvarA, myvarB, ... #}`. This will help a lot on complex cases like https://github.com/allocine/twigcs/issues/35 where there is no solution at the moment (twigcs evaluates templates one by one and does not explore includes or block re-uses).

I'm still expecting bugs and missing features in the future as these rules are complex but we should be able to handle them one by one when we encounter them (and the test suite will help to keep them fixed).