### PR TITLE
Fixed unclosed ternary operator in block causing crash

### DIFF
--- a/src/Rule/TernarySpacing.php
+++ b/src/Rule/TernarySpacing.php
@@ -87,7 +87,7 @@ class TernarySpacing extends AbstractSpacingRule implements RuleInterface
         while ($depth || !$found) {
             $token = $tokens->look($i);
 
-            if ($token->getType() === \Twig_Token::VAR_END_TYPE || $token->getType() === \Twig_Token::INTERPOLATION_END_TYPE) {
+            if (in_array($token->getType(), [\Twig_Token::BLOCK_END_TYPE, \Twig_Token::VAR_END_TYPE, \Twig_Token::INTERPOLATION_END_TYPE])) {
                 return;
             }
 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -122,6 +122,7 @@ class FunctionalTest extends TestCase
             ['{{ -1 }}', null],
             ['{{ -10 }}', null],
             ['{{ (-10) }}', null],
+            ['{% include "file" with {foo: bar ? baz } %}', null],
 
             // Use lower cased and underscored variable names.
             ['{% set foo = 1 %}{{ foo }}', null],


### PR DESCRIPTION
This fixes https://github.com/allocine/twigcs/issues/42