### PR TITLE
Added backward compatibility with twig 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: php
+env:
+  - TWIG_VERSION="^1.0"
+  - TWIG_VERSION="^2.0"
 php:
   - 7.0
   - 7.1
+  - 7.2
 before_install:
+    - composer require twig/twig:${TWIG_VERSION}
     - composer self-update
 install:
     - composer --prefer-source -n install

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -2,7 +2,14 @@
 
 namespace Allocine\Twigcs;
 
-use Allocine\Twigcs\Compatibility\TwigLexer;
+/**
+ * Backward compatibility with Twig 1.X
+ */
+if (\Twig_Environment::MAJOR_VERSION > 1) {
+    class_alias(\Allocine\Twigcs\Compatibility\TwigLexer::class, 'Allocine\Twigcs\BaseLexer');
+} else {
+    class_alias(\Twig_Lexer::class, 'Allocine\Twigcs\BaseLexer');
+}
 
 /**
  * An override of Twig's Lexer to add whitespace and new line detection.
@@ -10,7 +17,7 @@ use Allocine\Twigcs\Compatibility\TwigLexer;
  *
  * @author Tristan Maindron <tmaindron@gmail.com>
  */
-class Lexer extends TwigLexer
+class Lexer extends BaseLexer
 {
     const PREVIOUS_TOKEN = -1;
     const NEXT_TOKEN     = 1;


### PR DESCRIPTION
It also comes with a new travis test matrix based on both twig and php version. The library will be tested against the following combinations : 

- Twig 1.X with PHP 7.0, 7.1 and 7.2
- Twig 2.X with PHP 7.0, 7.1 and 7.2

This will fix https://github.com/allocine/twigcs/issues/43