### PR TITLE
Fixed undetected macro usage

### DIFF
--- a/src/Rule/UnusedMacro.php
+++ b/src/Rule/UnusedMacro.php
@@ -81,7 +81,11 @@ class UnusedMacro extends AbstractRule implements RuleInterface
                 $previous = $this->getPreviousSignificantToken($tokens);
                 $next = $this->getNextSignificantToken($tokens);
 
-                if (!in_array($previous->getValue(), ['.', '|']) && in_array($next->getValue(), ['('])) {
+                $isSubProperty = in_array($previous->getValue(), ['.', '|']);
+                $directUsage = in_array($next->getValue(), ['(']);
+                $dotUsage = ($this->getNextSignificantToken($tokens, 1)->getType() === \Twig_Token::NAME_TYPE) && in_array($this->getNextSignificantToken($tokens, 2)->getValue(), ['(']);
+
+                if (!$isSubProperty && ($directUsage || $dotUsage)) {
                     $scope->use($token->getValue());
                 }
 

--- a/src/Scope/Scope.php
+++ b/src/Scope/Scope.php
@@ -137,4 +137,25 @@ class Scope
 
         return false;
     }
+
+    /**
+     * @param int $tab
+     *
+     * @return string
+     */
+    public function dump(int $tab = 0): string
+    {
+        $declarations = implode(', ', array_keys($this->declarations));
+        $usages = implode(', ', $this->usages);
+
+        $self = sprintf("%s : {D : %s} {U : %s} \n", $name ?? 'noname', $declarations, $usages);
+
+        $children = "";
+
+        foreach ($this->children as $child) {
+            $children .= str_repeat(" ", $tab) . $child->dump($tab + 4) . "\n";
+        }
+
+        return $self . $children;
+    }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -157,6 +157,7 @@ class FunctionalTest extends TestCase
             ['{% from _self import foo as bar %}', 'Unused macro import "bar".'],
             ['{% from _self import foo as request %}{{ app.request.uri }}', 'Unused macro import "request".'],
             ['{% from _self import foo as macro %}{% macro foo() %}{% endmacro %}', 'Unused macro import "macro".'], // https://github.com/allocine/twigcs/issues/28
+            ['{% import "macros.html.twig" as macros %} {{ macros.stuff() }}', null],
 
             // Complex encountered cases
             ['{% set baz = foo is defined ? object.property : default %}{{ baz }}', null],


### PR DESCRIPTION
This fixes a regression where macro usage like `macro.foo()` were not properly detected.