### PR TITLE
Add a note about escaping backslashes in the ruleset FQCN

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ twigcs /path/to/views --ruleset \MyApp\TwigCsRuleset
 ```
 
 *Note:* `twigcs` needs to be used via composer and the ruleset class must be reachable via composer's autoloader for this feature to work.
+Also note that depending on your shell, you might need to escape backslashes in the fully qualified class name:
+
+```bash
+twigcs /path/to/views --ruleset \\MyApp\\TwigCsRuleset
+```
 
 ### Coming features
 

--- a/src/Console/LintCommand.php
+++ b/src/Console/LintCommand.php
@@ -10,6 +10,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
+use function class_exists;
+use function sprintf;
 
 class LintCommand extends ContainerAwareCommand
 {
@@ -47,6 +49,10 @@ class LintCommand extends ContainerAwareCommand
         $violations = [];
 
         $ruleset = $input->getOption('ruleset');
+
+        if (!class_exists($ruleset)) {
+            throw new \InvalidArgumentException(sprintf('Ruleset class %s does not exist', $ruleset));
+        }
 
         if (!is_subclass_of($ruleset, RulesetInterface::class)) {
             throw new \InvalidArgumentException('Ruleset class must implement '.RulesetInterface::class);


### PR DESCRIPTION
...and show a useful error message when the ruleset class does not exist.

Related to #70 