### PR TITLE
Remove composer self-update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ php:
   - 7.2
 before_install:
     - composer require twig/twig:${TWIG_VERSION}
-    - composer self-update
 install:
     - composer --prefer-source -n install


### PR DESCRIPTION
This is done by travis itself, so no need to run it twice