### PR TITLE
Test against twig 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,18 @@ language: php
 env:
   - TWIG_VERSION="^1.0"
   - TWIG_VERSION="^2.0"
+  - TWIG_VERSION="^3.0"
 php:
   - 7.0
   - 7.1
   - 7.2
   - 7.3
+jobs:
+  exclude:
+    - php: 7.0
+      env: TWIG_VERSION="^3.0"
+    - php: 7.1
+      env: TWIG_VERSION="^3.0"
 before_install:
     - composer require twig/twig:${TWIG_VERSION}
 install:


### PR DESCRIPTION
Twig 3.0 needs php 7.2 or up, so we exclude it for the php 7.0 and 7.1 tests