### PR TITLE
Fixed ScopedExpression on nested ternaries and parentheses

### DIFF
--- a/src/RegEngine/ScopedExpression.php
+++ b/src/RegEngine/ScopedExpression.php
@@ -81,7 +81,7 @@ class ScopedExpression
     {
         $head = $this->getHead();
 
-        return ($head instanceof self) && ('__TERNARY__' === $head->kind) && in_array($char, [',', '}'], true);
+        return ($head instanceof self) && ('__TERNARY__' === $head->kind) && in_array($char, [',', '}', ')', ']'], true);
     }
 
     public function shouldClose(string $char, $prev = null, $next = null)
@@ -145,7 +145,7 @@ class ScopedExpression
         $head = $this;
         $previousHead = null;
 
-        while ($head->head instanceof self) {
+        while ($head->head instanceof self && $head->head->open) {
             $previousHead = $head;
             $head = $head->head;
         }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -340,6 +340,9 @@ class FunctionalTest extends TestCase
             ['{% if not (foo and bar) %}', null],
             ['{% if not same as (foo and bar) %}', null],
 
+            // Check regression of https://github.com/friendsoftwig/twigcs/issues/105
+            ['{% block block_name \'some-text\' ~ (not a_function() ? \' other other-text-2\') %}', null],
+
             // Regressions from the official examples
             ['{% if \'Fabien\' starts with \'F\' %}', null],
             ['{% if \'Fabien\' ends with \'F\' %}', null],

--- a/tests/RegEngine/ScopedExpressionTest.php
+++ b/tests/RegEngine/ScopedExpressionTest.php
@@ -20,5 +20,21 @@ class ScopedExpressionTest extends TestCase
         $expr = new ScopedExpression();
         $expr->enqueueString('{{ {foo: a ? b, c}|sum }}');
         $this->assertSame('{{ [{foo: a ? b, c}]|sum }}', $expr->debug());
+
+        $expr = new ScopedExpression();
+        $expr->enqueueString('{{ [a ? b] }}');
+        $this->assertSame('{{ [[a ? b]] }}', $expr->debug());
+
+        $expr = new ScopedExpression();
+        $expr->enqueueString('{{ (a ? b) }}');
+        $this->assertSame('{{ [(a ? b)] }}', $expr->debug());
+
+        $expr = new ScopedExpression();
+        $expr->enqueueString('{{ (a ? b) + (c ? d : 1) }}');
+        $this->assertSame('{{ [(a ? b)] + [(c [? d :] 1)] }}', $expr->debug());
+
+        $expr = new ScopedExpression();
+        $expr->enqueueString('{{ (a ? foo()) }}');
+        $this->assertSame('{{ [(a ? foo[()])] }}', $expr->debug());
     }
 }


### PR DESCRIPTION
Fixes #105 and many more undiscovered bugs with ternaries mixed inside and around parentheses, arrays and hashes.