### PR TITLE
[RFC] [WIP] configuration via file & set different ruleset for given files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/finder": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/filesystem": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-        "pimple/pimple": "^3.0"
+        "pimple/pimple": "^3.0",
+        "symplify/smart-file-system": "^7.1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.2 || ^6.5"

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "twig/twig": "^1.41 || ^2.10 || ^3.0",
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/finder": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/filesystem": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "pimple/pimple": "^3.0"
     },
     "require-dev": {

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace FriendsOfTwig\Twigcs\Config;
+
+use FriendsOfTwig\Twigcs\Ruleset\Official;
+use Symfony\Component\Finder\Finder;
+
+class Config implements ConfigInterface
+{
+    private $name;
+    private $finder;
+    private $severity = 'warning';
+    private $reporter = 'reporter.console';
+    private $ruleset = Official::class;
+    private $specificRulesets = [];
+
+    public function __construct($name = 'default')
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return static
+     */
+    public static function create(): self
+    {
+        return new static();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFinder(): Finder
+    {
+        return $this->finder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFinder($finder): self
+    {
+        if (false === \is_array($finder) && false === $finder instanceof \Traversable) {
+            throw new \InvalidArgumentException(sprintf(
+                'Argument must be an array or a Traversable, got "%s".',
+                \is_object($finder) ? \get_class($finder) : \gettype($finder)
+            ));
+        }
+
+        $this->finder = $finder;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSeverity(): string
+    {
+        return $this->severity;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSeverity(string $severity): self
+    {
+        $this->severity = $severity;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReporter(): string
+    {
+        return $this->reporter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setReporter(string $reporter): self
+    {
+        $this->reporter = $reporter;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRuleset(): string
+    {
+        return $this->ruleset;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRuleset(string $ruleSet): self
+    {
+        $this->ruleset = $ruleSet;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSpecificRulesets(): array
+    {
+        return $this->specificRulesets;
+    }
+
+    /**
+     * @param array $ruleSet
+     * @return self
+     */
+    public function setSpecificRulesets(array $ruleSet): self
+    {
+        $this->specificRulesets = $ruleSet;
+
+        return $this;
+    }
+}

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -10,7 +10,7 @@ class Config implements ConfigInterface
     private $name;
     private $finder;
     private $severity = 'warning';
-    private $reporter = 'reporter.console';
+    private $reporter = 'console';
     private $ruleset = Official::class;
     private $specificRulesets = [];
 

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace FriendsOfTwig\Twigcs\Config;
+
+use Symfony\Component\Finder\Finder;
+
+interface ConfigInterface
+{
+    /**
+     * Returns the name of the configuration.
+     *
+     * The name must be all lowercase and without any spaces.
+     *
+     * @return string The name of the configuration
+     */
+    public function getName(): string;
+
+    /**
+     * @param string $name
+     * @return self
+     */
+    public function setName(string $name);
+
+    /**
+     * Returns files to scan.
+     *
+     * @return iterable|\Traversable
+     */
+    public function getFinder(): Finder;
+
+    /**
+     * @param iterable|string[]|\Traversable $finder
+     *
+     * @return self
+     */
+    public function setFinder($finder);
+
+    /**
+     * @return string
+     */
+    public function getSeverity(): string;
+
+    /**
+     * @param string $severity
+     * @return self
+     */
+    public function setSeverity(string $severity);
+
+    /**
+     * @return string
+     */
+    public function getReporter(): string;
+
+    /**
+     * @param string $reporter
+     * @return self
+     */
+    public function setReporter(string $reporter);
+
+    /**
+     * @return string
+     */
+    public function getRuleSet(): string;
+
+    /**
+     * @param string $ruleSet
+     * @return self
+     */
+    public function setRuleSet(string $ruleSet);
+
+    /**
+     * @return array
+     */
+    public function getSpecificRuleSets(): array;
+
+    /**
+     * @param array $ruleSet
+     * @return self
+     */
+    public function setSpecificRuleSets(array $ruleSet);
+}

--- a/src/Config/ConfigurationResolver.php
+++ b/src/Config/ConfigurationResolver.php
@@ -1,0 +1,398 @@
+<?php
+
+
+namespace FriendsOfTwig\Twigcs\Config;
+
+use Pimple\Container;
+use Symfony\Component\Filesystem\Filesystem;
+use FriendsOfTwig\Twigcs\Finder;
+use Symfony\Component\Finder\Finder as SymfonyFinder;
+use FriendsOfTwig\Twigcs\Ruleset\RulesetInterface;
+use FriendsOfTwig\Twigcs\Validator\Violation;
+use function fnmatch;
+
+final class ConfigurationResolver
+{
+    const PATH_MODE_OVERRIDE = 'override';
+    const PATH_MODE_INTERSECTION = 'intersection';
+
+    /**
+     * @var null|ConfigInterface
+     */
+    private $config;
+
+    /**
+     * @var null|string
+     */
+    private $configFile;
+
+    /**
+     * @var ConfigInterface
+     */
+    private $defaultConfig;
+
+    private $path;
+
+    /**
+     * Options which can be set via Cli
+     *
+     * @var array
+     */
+    private $options = [
+        'path' => [],
+        'path-mode' => self::PATH_MODE_OVERRIDE,
+        'severity' => null,
+        'reporter-service-name' => null,
+        'ruleset-class-name' => null,
+        'exclude' => [],
+        'config' => null,
+    ];
+
+    private $finder;
+
+    /**
+     * @var Container
+     */
+    private $container;
+    /**
+     * @var bool
+     */
+    private $configFinderIsOverridden;
+    private $cwd;
+    private $specificRulesets;
+
+    /**
+     * ConfigurationResolver constructor.
+     * @param Container $container
+     * @param $cwd
+     * @param array $options
+     */
+    public function __construct(Container $container, $cwd, array $options)
+    {
+        $this->container = $container;
+        $this->cwd = $cwd;
+        $this->defaultConfig = new Config();
+
+        foreach ($options as $name => $value) {
+            $this->setOption($name, $value);
+        }
+    }
+
+    public function getReporter()
+    {
+        //TODO: get reporter from config class
+        $reporterServiceName = "reporter.{$this->options['reporter-service-name']}";
+        return $this->container[$reporterServiceName];
+    }
+
+    /**
+     * Set option that will be resolved.
+     *
+     * @param string $name
+     * @param mixed  $value
+     */
+    private function setOption($name, $value)
+    {
+        if (!\array_key_exists($name, $this->options)) {
+            throw new InvalidConfigurationException(sprintf('Unknown option name: "%s".', $name));
+        }
+
+        $this->options[$name] = $value;
+    }
+
+    public function getRuleset(string $file)
+    {
+        $rulesetClassName = $this->getSpecificRuleset($file);
+
+        if (null === $rulesetClassName) {
+            $rulesetClassName = $this->config->getRuleset();
+            if ($this->options['ruleset-class-name']) {
+                $rulesetClassName = $this->options['ruleset-class-name'];
+            }
+        }
+
+        if (!class_exists($rulesetClassName)) {
+            throw new \InvalidArgumentException(sprintf('Ruleset class %s does not exist', $rulesetClassName));
+        }
+
+        if (!is_subclass_of($rulesetClassName, RulesetInterface::class)) {
+            throw new \InvalidArgumentException('Ruleset class must implement '.RulesetInterface::class);
+        }
+
+        return new $rulesetClassName();
+    }
+
+    /**
+     * File/Glob specific Ruleset definition. cannot be set via cli
+     *
+     * @param string $file
+     * @return mixed|null
+     */
+    private function getSpecificRuleset(string $file)
+    {
+        if (null === $this->specificRulesets) {
+            $this->specificRulesets = $this->getConfig()->getSpecificRulesets();
+        }
+
+        $file = $this->normalizePath($file);
+        foreach ($this->specificRulesets as $pattern => $rulesetClassName) {
+            // TODO: fnmatch allow setting flags https://www.php.net/manual/en/function.fnmatch.php
+            $pattern = $this->normalizePath($pattern);
+            if ($file === $pattern || fnmatch($pattern, $file)) {
+
+                return $rulesetClassName;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizePath(string $path): string
+    {
+        return str_replace('\\','/',$path);
+    }
+
+    private function getSeverity()
+    {
+        if (null !== $this->options['severity']) {
+            return $this->options['severity'];
+        }
+
+        return $this->getConfig()->getSeverity();
+    }
+
+    public function getSeverityLimit()
+    {
+        switch ($this->getSeverity()) {
+            case 'ignore':
+                return Violation::SEVERITY_IGNORE - 1;
+            case 'info':
+                return Violation::SEVERITY_INFO - 1;
+            case 'warning':
+                return Violation::SEVERITY_WARNING - 1;
+            case 'error':
+                return Violation::SEVERITY_ERROR - 1;
+            default:
+                throw new \InvalidArgumentException('Invalid severity limit provided.');
+        }
+    }
+
+    public function getConfig(): ConfigInterface
+    {
+        if (null === $this->config) {
+            foreach ($this->computeConfigFiles() as $configFile) {
+                if (!file_exists($configFile)) {
+                    continue;
+                }
+                $config = self::separatedContextLessInclude($configFile);
+
+                // verify that the config has an instance of Config
+                if (!$config instanceof ConfigInterface) {
+                    throw new InvalidConfigurationException(sprintf('The config file: "%s" does not return a "PhpCsFixer\ConfigInterface" instance. Got: "%s".', $configFile, \is_object($config) ? \get_class($config) : \gettype($config)));
+                }
+
+                $this->config = $config;
+                $this->configFile = $configFile;
+
+                break;
+            }
+
+            if (null === $this->config) {
+                $this->config = $this->defaultConfig;
+            }
+        }
+
+        return $this->config;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getConfigFile()
+    {
+        if (null === $this->configFile) {
+            $this->getConfig();
+        }
+
+        return $this->configFile;
+    }
+
+
+    public function getFinder()
+    {
+        if (null === $this->finder) {
+            $this->finder = $this->resolveFinder();
+        }
+
+        return $this->finder;
+    }
+
+    private function getPath()
+    {
+        if (null === $this->path) {
+            $filesystem = new Filesystem();
+            $cwd = $this->cwd;
+
+            if (1 === \count($this->options['path']) && '-' === $this->options['path'][0]) {
+                $this->path = $this->options['path'];
+            } else {
+                $this->path = array_map(
+                    static function ($path) use ($cwd, $filesystem) {
+                        $absolutePath = $filesystem->isAbsolutePath($path)
+                            ? $path
+                            : $cwd.\DIRECTORY_SEPARATOR.$path;
+
+                        if (!file_exists($absolutePath)) {
+                            throw new InvalidConfigurationException(sprintf(
+                                'The path "%s" is not readable.',
+                                $path
+                            ));
+                        }
+
+                        return $absolutePath;
+                    },
+                    $this->options['path']
+                );
+            }
+        }
+
+        return $this->path;
+    }
+
+    /**
+     * Apply path on config instance.
+     */
+    private function resolveFinder()
+    {
+        $this->configFinderIsOverridden = false;
+
+        $modes = [self::PATH_MODE_OVERRIDE, self::PATH_MODE_INTERSECTION];
+
+        if (!\in_array(
+            $this->options['path-mode'],
+            $modes,
+            true
+        )) {
+            throw new InvalidConfigurationException(sprintf(
+                'The path-mode "%s" is not defined, supported are "%s".',
+                $this->options['path-mode'],
+                implode('", "', $modes)
+            ));
+        }
+
+        $isIntersectionPathMode = self::PATH_MODE_INTERSECTION === $this->options['path-mode'];
+
+        $paths = array_filter(array_map(
+            static function ($path) {
+                return realpath($path);
+            },
+            $this->getPath()
+        ));
+
+        if (!\count($paths)) {
+            if ($isIntersectionPathMode) {
+                return new \ArrayIterator([]);
+            }
+
+            return $this->iterableToTraversable($this->getConfig()->getFinder());
+        }
+
+        $pathsByType = [
+            'file' => [],
+            'dir' => [],
+        ];
+
+        foreach ($paths as $path) {
+            if (is_file($path)) {
+                $pathsByType['file'][] = $path;
+            } else {
+                $pathsByType['dir'][] = $path.\DIRECTORY_SEPARATOR;
+            }
+        }
+
+        $nestedFinder = null;
+        $currentFinder = $this->iterableToTraversable($this->getConfig()->getFinder());
+
+        try {
+            $nestedFinder = $currentFinder instanceof \IteratorAggregate ? $currentFinder->getIterator() : $currentFinder;
+        } catch (\Exception $e) {
+        }
+
+        if ($isIntersectionPathMode) {
+            if (null === $nestedFinder) {
+                throw new InvalidConfigurationException(
+                    'Cannot create intersection with not-fully defined Finder in configuration file.'
+                );
+            }
+
+            return new \CallbackFilterIterator(
+                $nestedFinder,
+                static function (\SplFileInfo $current) use ($pathsByType) {
+                    $currentRealPath = $current->getRealPath();
+
+                    if (\in_array($currentRealPath, $pathsByType['file'], true)) {
+                        return true;
+                    }
+
+                    foreach ($pathsByType['dir'] as $path) {
+                        if (0 === strpos($currentRealPath, $path)) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+            );
+        }
+
+        if (null !== $this->getConfigFile() && null !== $nestedFinder) {
+            $this->configFinderIsOverridden = true;
+        }
+
+        if ($currentFinder instanceof SymfonyFinder && null === $nestedFinder) {
+            // finder from configuration Symfony finder and it is not fully defined, we may fulfill it
+            return $currentFinder->in($pathsByType['dir'])->append($pathsByType['file'])->exclude($this->options['exclude']);
+        }
+
+        return Finder::create()->in($pathsByType['dir'])->append($pathsByType['file'])->exclude('vendor');
+    }
+
+    /**
+     * @param iterable $iterable
+     *
+     * @return \Traversable
+     */
+    private function iterableToTraversable($iterable)
+    {
+        return \is_array($iterable) ? new \ArrayIterator($iterable) : $iterable;
+    }
+
+    /**
+     * Compute file candidates for config file.
+     *
+     * @return string[]
+     */
+    private function computeConfigFiles()
+    {
+        $configFile = $this->options['config'];
+
+        if (null !== $configFile) {
+            if (false === file_exists($configFile) || false === is_readable($configFile)) {
+                throw new InvalidConfigurationException(sprintf('Cannot read config file "%s".', $configFile));
+            }
+
+            return [$configFile];
+        }
+        $configDir = $this->cwd;
+
+        return [
+            $configDir.\DIRECTORY_SEPARATOR.'.twig_cs',
+            $configDir.\DIRECTORY_SEPARATOR.'.twig_cs.dist',
+        ];
+    }
+
+    private static function separatedContextLessInclude($path)
+    {
+        return include $path;
+    }
+}

--- a/src/Config/ConfigurationResolver.php
+++ b/src/Config/ConfigurationResolver.php
@@ -80,8 +80,11 @@ final class ConfigurationResolver
 
     public function getReporter()
     {
-        //TODO: get reporter from config class
-        $reporterServiceName = "reporter.{$this->options['reporter-service-name']}";
+        $reporterServiceName = "reporter.{$this->config->getReporter()}";
+        if ($this->options['ruleset-class-name']) {
+            $reporterServiceName = "reporter.{$this->options['reporter-service-name']}";
+        }
+
         return $this->container[$reporterServiceName];
     }
 

--- a/src/Config/InvalidConfigurationException.php
+++ b/src/Config/InvalidConfigurationException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace FriendsOfTwig\Twigcs\Config;
+
+
+class InvalidConfigurationException extends \InvalidArgumentException
+{
+
+}

--- a/src/Console/LintCommand.php
+++ b/src/Console/LintCommand.php
@@ -61,18 +61,18 @@ class LintCommand extends ContainerAwareCommand
         // TODO: should be refactored to a Runner class
         foreach ($files as $file) {
             /** @var SmartFileInfo $file */
-            var_dump(
+//            var_dump(
 //                'getRelativeFilePath',
 //                $file->getRelativeFilePath(),
 //                $file->getRelativePathname(),
 //                ''
-                'getRelativeFilePathFromCwd',
-                $file->getRelativeFilePathFromCwd(),
+//                'getRelativeFilePathFromCwd',
+//                $file->getRelativeFilePathFromCwd(),
 //                'getRelativePathname',
 //                $file->getRelativePathname(),
 //                'getRelativeFilePathFromDirectory',
 //                $file->getRelativeFilePathFromDirectory(getcwd())
-            );
+//            );
 
 
             $ruleset = $resolver->getRuleset($file->getRelativePathname());

--- a/src/Console/LintCommand.php
+++ b/src/Console/LintCommand.php
@@ -9,6 +9,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\SplFileInfo;
+use Symplify\SmartFileSystem\Finder\FinderSanitizer;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 class LintCommand extends ContainerAwareCommand
 {
@@ -52,16 +54,34 @@ class LintCommand extends ContainerAwareCommand
 
         $violations = [];
 
+        $finderSanitizer = new FinderSanitizer();
+        $files = $finderSanitizer->sanitize($finder);
+//        $files = $finder;
+
         // TODO: should be refactored to a Runner class
-        foreach ($finder as $file) {
-            /** @var SplFileInfo $file */
+        foreach ($files as $file) {
+            /** @var SmartFileInfo $file */
+            var_dump(
+//                'getRelativeFilePath',
+//                $file->getRelativeFilePath(),
+//                $file->getRelativePathname(),
+//                ''
+                'getRelativeFilePathFromCwd',
+                $file->getRelativeFilePathFromCwd(),
+//                'getRelativePathname',
+//                $file->getRelativePathname(),
+//                'getRelativeFilePathFromDirectory',
+//                $file->getRelativeFilePathFromDirectory(getcwd())
+            );
+
 
             $ruleset = $resolver->getRuleset($file->getRelativePathname());
             $currentViolations = $validator->validate($ruleset, $twig->tokenize(new \Twig\Source(
                 file_get_contents($file->getRealPath()),
                 $file->getRealPath(),
                 // TODO: relative path is without base dir if multiple in's are given.
-                $file->getRelativePathname()
+//                $file->getRelativePathname(),
+                $file->getRelativeFilePathFromCwd()
             )));
 
             // TODO: change array_merge to something more efficient

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FriendsOfTwig\Twigcs;
+
+use Symfony\Component\Finder\Finder as BaseFinder;
+
+class Finder extends BaseFinder
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this
+            ->files()
+            ->name('*.twig')
+            ->ignoreDotFiles(true)
+            ->ignoreVCS(true)
+        ;
+    }
+}

--- a/tests/Ruleset/SuppressWarningForUnusedVariable.php
+++ b/tests/Ruleset/SuppressWarningForUnusedVariable.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace FriendsOfTwig\Twigcs\Tests\Ruleset;
+
+use FriendsOfTwig\Twigcs\RegEngine\RulesetBuilder;
+use FriendsOfTwig\Twigcs\RegEngine\RulesetConfigurator;
+use FriendsOfTwig\Twigcs\Rule;
+use FriendsOfTwig\Twigcs\Validator\Violation;
+use FriendsOfTwig\Twigcs\Ruleset\RulesetInterface;
+
+/**
+ * The official twigcs ruleset, based on http://twig.sensiolabs.org/doc/coding_standards.html.
+ *
+ * @author Tristan Maindron <tmaindron@gmail.com>
+ */
+class SuppressWarningForUnusedVariable implements RulesetInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getRules()
+    {
+        $builder = new RulesetBuilder(new RulesetConfigurator());
+
+        return [
+            new Rule\LowerCaseVariable(Violation::SEVERITY_ERROR),
+            new Rule\RegEngineRule(Violation::SEVERITY_ERROR, $builder->build()),
+            new Rule\TrailingSpace(Violation::SEVERITY_ERROR),
+            new Rule\UnusedMacro(Violation::SEVERITY_WARNING),
+        ];
+    }
+}


### PR DESCRIPTION
i forked this nice tool because i wanted to integrate it into my ci pipeline but had problems with specific files i have no permission to change (vendor files i overwrite and changing the content of some of their variables). for example extending knpmenu can lead to code like this `{%- set childrenClasses = childrenClasses|merge({'class': 'link'}) -%}` which triggers the `LowerCaseVariable` rule.
of course i can disable the `LowerCaseVariable` completly in a custom ruleset but i just want to disable the rule for this specific file and still use all other rules for this file and use the official ruleset for all my other files. so i extended this tool, mainly with the code from phpcs fixer, to be able to do so.

new features:

- set the config in a config file `.twig_cs`. `.twig_cs.dist` and custom filename
- white/blacklsit with full finder configuration with multiple `in`, `exclude`, `path`, `notInPath`,... 
- set per file rules (can be a glob or a path)
- maybe a little bit faster because of a single finder instance

changes:
- argument name `paths` to `path`

to discuss:
- how to handle different basepaths? currently there is a bug if multiple paths are given #116 which shows the wrong basepath if multiple are given. after my change only a single finder is used which also can have multiple basepaths which i won't reccomend, as the relative path is calulated from the basepath. 
- should the magic be removed from generating the reporter service name (no auto append from `reporter.` in config. what about cli?

having the following dir structure:
```
templates
    foo
        bar.html.twig
other-templates
    foo
        bar.html.twig
```

if i provide `templates` and `other-templates` as `->in()` parameter for the finder and i have an error in both `bar.html.twig` files i will get the following path output:
```
foo/bar.html.twig
foo/bar.html.twig
```
the bug in the old behvior would lead to:
```
other-templates/foo/bar.html.twig
other-templates/foo/bar.html.twig
```
as the last path is `other-templates`. the fix would be to use multiple finder or some lookup map. i would suggest to stick with one finder with one basedir and work with `exclude()` then the relative paths are shown correct

example config `.twig_cs.dist`:

```php
<?php
$finder = FriendsOfTwig\Twigcs\Finder::create()
    ->in(__DIR__)
    ->exclude('templates')
;

return \FriendsOfTwig\Twigcs\Config\Config::create()
    ->setFinder($finder)
    ->setSeverity('warning')
    ->setReporter('reporter.console')
    ->setName('my-config')
    ->setRuleSet(FriendsOfTwig\Twigcs\Ruleset\Official::class)
    ->setSpecificRuleSets([
        '*/warning.html.twig' => FriendsOfTwig\Twigcs\Tests\Ruleset\SuppressWarningForUnusedVariable::class,
        '*/errors.html.twig' => FriendsOfTwig\Twigcs\Ruleset\Official::class,
        'tests\data\valid_corpus\form_div_layout.html.twig' => FriendsOfTwig\Twigcs\Ruleset\Official::class,
    ])
;
```

todo:
- [ ] credit authors from copied code (phpcs fixer)
- [ ] check custom config file name
- [ ] add/fix tests
- [ ] phpdoc
- [ ] check path modes
- [ ] output if finder is overridden
- [ ] fix `TODO`s
- [ ] add info to readme