### PR TITLE
Ability to display either all violations, or only those blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Tips: You can use multiple _exclude_ parameters.
 ## Restricting output
 
 By default TwigCS will output all lines that have violations regardless of whether they match the severity level
-specified or not. If you only want to see errors that are greater than or equal to the severity level you've specified
+specified or not. If you only want to see violations that are greater than or equal to the severity level you've specified
 you can use the `--display` option. For example. 
 
 ```bash
@@ -55,6 +55,8 @@ twigcs /path/to/views --severity error --display blocking
 ```
 
 Would only display errors and not warnings.
+
+Alternatively you can use `--display all` which is the default behaviour as described above.
 
 ### Continuous Integration
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ twigcs /path/to/views --exclude vendor
 
 Tips: You can use multiple _exclude_ parameters.
 
+## Restricting output
+
+By default TwigCS will output all lines that have violations regardless of whether they match the severity level
+specified or not. If you only want to see errors that are greater than or equal to the severity level you've specified
+you can use the `--display` option. For example. 
+
+```bash
+twigcs /path/to/views --severity error --display blocking
+```
+
+Would only display errors and not warnings.
+
 ### Continuous Integration
 
 Twigcs can be used with your favorite CI server. The command itself will return a consistent exit code telling

--- a/src/Console/LintCommand.php
+++ b/src/Console/LintCommand.php
@@ -36,7 +36,6 @@ class LintCommand extends ContainerAwareCommand
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $container = $this->getContainer();
-        $limit = $this->getSeverityLimit($input);
 
         $paths = $input->getArgument('paths');
         $exclude = $input->getOption('exclude');
@@ -105,14 +104,9 @@ class LintCommand extends ContainerAwareCommand
 
         $limit = $this->getSeverityLimit($input);
 
-        $filteredViolations = [];
-        foreach ($violations as $violation) {
-            if ($violation->getSeverity() > $limit) {
-                $filteredViolations[] = $violation;
-            }
-        }
-
-        return $filteredViolations;
+        return array_filter($violations, function(Violation $violation) use ($limit) {
+            return $violation->getSeverity() > $limit;
+        });
     }
 
     private function getSeverityLimit(InputInterface $input): int

--- a/src/Console/LintCommand.php
+++ b/src/Console/LintCommand.php
@@ -16,6 +16,9 @@ use function sprintf;
 
 class LintCommand extends ContainerAwareCommand
 {
+    const DISPLAY_BLOCKING = 'blocking';
+    const DISPLAY_ALL = 'all';
+
     public function configure()
     {
         $this
@@ -25,6 +28,7 @@ class LintCommand extends ContainerAwareCommand
             ->addOption('exclude', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'Excluded folder of path.', [])
             ->addOption('severity', 's', InputOption::VALUE_REQUIRED, 'The maximum allowed error level.', 'warning')
             ->addOption('reporter', 'r', InputOption::VALUE_REQUIRED, 'The reporter to use.', 'console')
+            ->addOption('display', 'd', InputOption::VALUE_REQUIRED, 'The violations to display, "' . self::DISPLAY_ALL . '" or "' . self::DISPLAY_BLOCKING . '".', self::DISPLAY_ALL)
             ->addOption('ruleset', null, InputOption::VALUE_REQUIRED, 'Ruleset class to use', Official::class)
         ;
     }
@@ -60,7 +64,7 @@ class LintCommand extends ContainerAwareCommand
         }
 
         if (!is_subclass_of($ruleset, RulesetInterface::class)) {
-            throw new \InvalidArgumentException('Ruleset class must implement '.RulesetInterface::class);
+            throw new \InvalidArgumentException('Ruleset class must implement ' . RulesetInterface::class);
         }
 
         foreach ($files as $file) {
@@ -73,7 +77,16 @@ class LintCommand extends ContainerAwareCommand
             $violations = array_merge($violations, $container->get('validator')->validate(new $ruleset($twigVersion), $tokens));
         }
 
+        $violations = $this->filterDisplayViolations($input, $violations);
+
         $container->get(sprintf('reporter.%s', $input->getOption('reporter')))->report($output, $violations);
+
+        return $this->determineExitCode($input, $violations);
+    }
+
+    private function determineExitCode(InputInterface $input, array $violations): int
+    {
+        $limit = $this->getSeverityLimit($input);
 
         foreach ($violations as $violation) {
             if ($violation->getSeverity() > $limit) {
@@ -84,7 +97,25 @@ class LintCommand extends ContainerAwareCommand
         return 0;
     }
 
-    private function getSeverityLimit(InputInterface $input)
+    private function filterDisplayViolations(InputInterface $input, array $violations): array
+    {
+        if (self::DISPLAY_ALL === $input->getOption('display')) {
+            return $violations;
+        }
+
+        $limit = $this->getSeverityLimit($input);
+
+        $filteredViolations = [];
+        foreach ($violations as $violation) {
+            if ($violation->getSeverity() > $limit) {
+                $filteredViolations[] = $violation;
+            }
+        }
+
+        return $filteredViolations;
+    }
+
+    private function getSeverityLimit(InputInterface $input): int
     {
         switch ($input->getOption('severity')) {
             case 'ignore':

--- a/src/Validator/Violation.php
+++ b/src/Validator/Violation.php
@@ -40,7 +40,6 @@ class Violation
     private $source;
 
     /**
-     * Violation constructor.
      * @param $filename
      * @param $line
      * @param $column

--- a/src/Validator/Violation.php
+++ b/src/Validator/Violation.php
@@ -40,9 +40,13 @@ class Violation
     private $source;
 
     /**
-     * @param string $filename
-     * @param int    $line
-     * @param string $reason
+     * Violation constructor.
+     * @param $filename
+     * @param $line
+     * @param $column
+     * @param $reason
+     * @param int $severity
+     * @param string $source
      */
     public function __construct($filename, $line, $column, $reason, $severity = self::SEVERITY_ERROR, $source = 'unknown')
     {

--- a/tests/Console/LintCommandTest.php
+++ b/tests/Console/LintCommandTest.php
@@ -93,4 +93,38 @@ class LintCommandTest extends TestCase
         $this->assertSame($statusCode, 0);
         $this->assertContains('No violation found.', $output);
     }
+
+    public function testErrorsOnlyDisplayBlocking()
+    {
+        $this->commandTester->execute([
+            'paths' => ['tests/data/exclusion/bad/mixed.html.twig'],
+            '--severity' => 'error',
+            '--display' => LintCommand::DISPLAY_BLOCKING,
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $statusCode = $this->commandTester->getStatusCode();
+        $this->assertSame($statusCode, 1);
+        $this->assertNotContains('l.1 c.7 : WARNING Unused variable "foo".', $output);
+        $this->assertContains('l.2 c.2 : ERROR A print statement should start with 1 space.', $output);
+        $this->assertContains('l.2 c.13 : ERROR There should be 0 space between the closing parenthese and its content.', $output);
+        $this->assertContains('2 violation(s) found', $output);
+    }
+
+    public function testErrorsDisplayAll()
+    {
+        $this->commandTester->execute([
+            'paths' => ['tests/data/exclusion/bad/mixed.html.twig'],
+            '--severity' => 'error',
+            '--display' => LintCommand::DISPLAY_ALL,
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $statusCode = $this->commandTester->getStatusCode();
+        $this->assertSame($statusCode, 1);
+        $this->assertContains('l.1 c.7 : WARNING Unused variable "foo".', $output);
+        $this->assertContains('l.2 c.2 : ERROR A print statement should start with 1 space.', $output);
+        $this->assertContains('l.2 c.13 : ERROR There should be 0 space between the closing parenthese and its content.', $output);
+        $this->assertContains('3 violation(s) found', $output);
+    }
 }

--- a/tests/data/exclusion/bad/mixed.html.twig
+++ b/tests/data/exclusion/bad/mixed.html.twig
@@ -1,0 +1,2 @@
+{% set foo = 1 %}
+{{dump('twig' ) }}


### PR DESCRIPTION
This PR address #104  the ability to filter the output of the LintCommand. The new option `display` has 2 valid values:

`blocking` - Is all violations causing a non-zero exit code

`all` - Is all violations, regardless of whether they caused a non-zero exit code or not

So for example:

```
php bin/twigcs ./tests/data/exclusion/bad/mixed.html.twig --severity=error --display=blocking
```
Would output only ERRORs

```
php bin/twigcs ./tests/data/exclusion/bad/mixed.html.twig --severity=error --display=all
```
Would output ERRORs and WARNINGs