### PR TITLE
Add lower case detection in 'for' tags

### DIFF
--- a/src/Rule/LowerCaseVariable.php
+++ b/src/Rule/LowerCaseVariable.php
@@ -18,8 +18,21 @@ class LowerCaseVariable extends AbstractRule implements RuleInterface
         while (!$tokens->isEOF()) {
             $token = $tokens->getCurrent();
 
-            if (Token::NAME_TYPE === $token->getType() && preg_match('/[A-Z]/', $token->getValue())) {
-                if (Token::WHITESPACE_TYPE === $tokens->look(Lexer::PREVIOUS_TOKEN)->getType() && 'set' === $tokens->look(-2)->getValue()) {
+            if (Token::NAME_TYPE === $token->getType() &&
+                preg_match('/[A-Z]/', $token->getValue()) &&
+                Token::WHITESPACE_TYPE === $tokens->look(Lexer::PREVIOUS_TOKEN)->getType()
+            ) {
+                $hasViolation = false;
+                if (in_array($tokens->look(-2)->getValue(), ['set', 'for'])) {
+                    $hasViolation = true;
+                } else if (',' === $tokens->look(-2)->getValue() &&
+                    Token::WHITESPACE_TYPE === $tokens->look(-4)->getType() &&
+                    'for' === $tokens->look(-5)->getValue()
+                ) {
+                    $hasViolation = true;
+                }
+
+                if ($hasViolation) {
                     $violations[] = $this->createViolation($tokens->getSourceContext()->getPath(), $token->getLine(), $token->getColumn(), sprintf('The "%s" variable should be in lower case (use _ as a separator).', $token->getValue()));
                 }
             }

--- a/tests/Twig3FunctionalTest.php
+++ b/tests/Twig3FunctionalTest.php
@@ -146,6 +146,13 @@ class Twig3FunctionalTest extends TestCase
             ['{% set foo = 1 %}{{ foo }}', null],
             ['{% set foo_bar = 1 %}{{ foo_bar }}', null],
             ['{% set fooBar = 1 %}{{ fooBar }}', 'The "fooBar" variable should be in lower case (use _ as a separator).'],
+            ['{% for foo in 1..10 %}{{ foo }}{% endfor %}', null],
+            ['{% for foo_bar in 1..10 %}{{ foo_bar }}{% endfor %}', null],
+            ['{% for fooBar in 1..10 %}{{ fooBar }}{% endfor %}', 'The "fooBar" variable should be in lower case (use _ as a separator).'],
+            ['{% for foo, bar in 1..10 %}{{ foo }}: {{ bar }}{% endfor %}', null],
+            ['{% for foo_key, bar_val in 1..10 %}{{ foo_key }}: {{ bar_val }}{% endfor %}', null],
+            ['{% for fooKey, bar_val in 1..10 %}{{ fooKey }}: {{ bar_val }}{% endfor %}', 'The "fooKey" variable should be in lower case (use _ as a separator).'],
+            ['{% for foo_key, barVal in 1..10 %}{{ foo_key }}: {{ barVal }}{% endfor %}', 'The "barVal" variable should be in lower case (use _ as a separator).'],
 
             // var declaration spacing
             ['{% set  foo = 1 %}{{ foo }}', 'There should be 1 space after the "set".'],


### PR DESCRIPTION
When you define new variables with the "for" tag, they must be lowercase.

| Wrong                                        | Correct                                        |
|----------------------------------------------|------------------------------------------------|
| {% for fooBar in data %}{% endfor %}         | {% for foo_bar in data %}{% endfor %}          |
| {% for fooKey, barVal in data %}{% endfor %} | {% for foo_key, bar_val in data %}{% endfor %} |