### PR TITLE
Added named arguments support

### DIFF
--- a/doc/regengine.md
+++ b/doc/regengine.md
@@ -74,6 +74,7 @@ $configurator->setTagSpacingPattern('{% expr %}');
 $configurator->setTernarySpacingPattern('expr ? expr : expr||expr ?: expr');
 $configurator->setUnaryOpSpacingPattern('op expr');
 $configurator->setArrowFunctionSpacingPattern('args => expr');
+$configurator->setNamedArgsSpacingPattern('name=value, expr');
 ```
 
 ## Fully custom rules : beware of the dragons !

--- a/src/RegEngine/RulesetConfigurator.php
+++ b/src/RegEngine/RulesetConfigurator.php
@@ -31,6 +31,7 @@ class RulesetConfigurator
     const TERNARY_SPACING_PATTERN = '#^expr( *)\?( *)expr( *)\:( *)expr\|\|expr( *)\?\:( *)expr$#';
     const PROPERTY_SPACING_PATTERN = '#^expr( *)\.( *)expr( *)\|( *)filter$#';
     const ARROW_FUNCTION_SPACING_PATTERN = '#^args( *)=>( *)expr$#';
+    const NAMED_ARGS_SPACING_PATTERN = '#^name( *)=( *)value( *),( *)expr$#';
 
     private $macroSpacingPattern = 'macro name(expr)';
     private $tagSpacingPattern = '{% expr %}';
@@ -60,6 +61,7 @@ class RulesetConfigurator
     private $tagDefaultArgSpacing = 1; // Default space used between tag arguments : {% foo arg1 arg2 %}
     private $emptyListWhitespaces = 0;
     private $arrowFunctionSpacingPattern = 'args => expr';
+    private $namedArgsSpacingPattern = 'name=value, expr';
     private $twigMajorVersion = 3;
 
     public function getProcessedConfiguration()
@@ -194,6 +196,11 @@ class RulesetConfigurator
         preg_match(self::ARROW_FUNCTION_SPACING_PATTERN, $this->arrowFunctionSpacingPattern, $matches);
         $config['arrow_function']['before_arrow'] = strlen($matches[1]);
         $config['arrow_function']['after_arrow'] = strlen($matches[2]);
+
+        preg_match(self::NAMED_ARGS_SPACING_PATTERN, $this->namedArgsSpacingPattern, $matches);
+        $config['named_args']['before_='] = strlen($matches[1]);
+        $config['named_args']['after_='] = strlen($matches[2]);
+        $config['named_args']['after_value'] = strlen($matches[3]);
 
         $config['tag_default_arg_spacing'] = $this->tagDefaultArgSpacing;
         $config['empty_list_whitespaces'] = $this->emptyListWhitespaces;
@@ -386,6 +393,13 @@ class RulesetConfigurator
     public function setPropertySpacingPattern(string $propertySpacingPattern): self
     {
         $this->propertySpacingPattern = $propertySpacingPattern;
+
+        return $this;
+    }
+
+    public function setNamedArgsSpacingPattern(int $namedArgsSpacingPattern): self
+    {
+        $this->namedArgsSpacingPattern = $namedArgsSpacingPattern;
 
         return $this;
     }

--- a/tests/Twig3FunctionalTest.php
+++ b/tests/Twig3FunctionalTest.php
@@ -163,7 +163,6 @@ class Twig3FunctionalTest extends TestCase
             ['{{ 1    b-or 2 }}', 'There should be 1 space between the "b-or" operator and its left operand.'],
             ['{{ 1 b-or    2 }}', 'There should be 1 space between the "b-or" operator and its right operand.'],
 
-
             // Use lower cased and underscored variable names.
             ['{% set foo = 1 %}{{ foo }}', null],
             ['{% set foo_bar = 1 %}{{ foo_bar }}', null],
@@ -340,6 +339,13 @@ class Twig3FunctionalTest extends TestCase
             ['        {%- set vars = widget == "text" ? {"attr": {"size": 1 }} : {} -%}{{ vars }}', 'There should be 0 space after the hash values.', [61, 1]],
             ['{{ {foo: {bar: {baz: {foo: {bar: 1 }}}}} }}', 'There should be 0 space after the hash values.', [34, 1]],
             ['{{ {foo: {bar: 1}}|agg + {baz: 2 }|agg }}', 'There should be 0 space after the hash values.', [32, 1]],
+
+            // Check for named args
+            ['{{ foo(bar=1, baz=2) }}', null],
+            ['{{ foo(1, 2, 3, bar=1, baz=2) }}', null],
+            ['{{ foo(bar =1, baz=2) }}', 'There should be 0 space before the "=" in the named arguments list.'],
+            ['{{ foo(bar= 1, baz=2) }}', 'There should be 0 space after the "=" in the named arguments list.'],
+            ['{{ foo(bar=1 , baz=2) }}', 'There should be 0 space after the value in the named arguments list.'],
 
             // Check regression of https://github.com/friendsoftwig/twigcs/issues/62
             ['{%~ if foo ~%}', null],

--- a/tests/data/valid_corpus/named_args.html.twig
+++ b/tests/data/valid_corpus/named_args.html.twig
@@ -1,0 +1,2 @@
+{{ range(low=1, high=10, step=2) }}
+{{ range(low=1, high=10, step=range(low=1, high=10, step=range(low=1, high=10, step=2))) }}


### PR DESCRIPTION
This fixes #138 

The approach here is to handle argument lists like other lists but with added syntax matching. There is also a trick to avoid breaking arrow functions.