### PR TITLE
Issue #146 : Add reporters

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -4,7 +4,9 @@ namespace FriendsOfTwig\Twigcs;
 
 use FriendsOfTwig\Twigcs\Reporter\CheckstyleReporter;
 use FriendsOfTwig\Twigcs\Reporter\ConsoleReporter;
+use FriendsOfTwig\Twigcs\Reporter\CsvReporter;
 use FriendsOfTwig\Twigcs\Reporter\EmacsReporter;
+use FriendsOfTwig\Twigcs\Reporter\GithubActionReporter;
 use FriendsOfTwig\Twigcs\Reporter\JUnitReporter;
 use FriendsOfTwig\Twigcs\Validator\Validator;
 use FriendsOfTwig\Twigcs\Reporter\JsonReporter;
@@ -31,6 +33,14 @@ class Container extends \ArrayObject
 
         $this['reporter.json'] = function () {
             return new JsonReporter();
+        };
+
+        $this['reporter.csv'] = function () {
+            return new CsvReporter();
+        };
+
+        $this['reporter.githubAction'] = function () {
+            return new GithubActionReporter();
         };
 
         $this['lexer'] = function () {

--- a/src/Reporter/CsvReporter.php
+++ b/src/Reporter/CsvReporter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace FriendsOfTwig\Twigcs\Reporter;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CsvReporter implements ReporterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function report(OutputInterface $output, array $violations)
+    {
+        foreach ($violations as $violation) {
+            $output->writeln(sprintf(
+                '%s;%d;%d;%s - %s',
+                $violation->getFilename(),
+                $violation->getLine(),
+                $violation->getColumn(),
+                strtolower($violation->getSeverityAsString()),
+                $violation->getReason()
+            ));
+        }
+    }
+}

--- a/src/Reporter/GithubActionReporter.php
+++ b/src/Reporter/GithubActionReporter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace FriendsOfTwig\Twigcs\Reporter;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GithubActionReporter implements ReporterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function report(OutputInterface $output, array $violations)
+    {
+        foreach ($violations as $violation) {
+            $output->writeln(sprintf(
+                '::%s file=%s, line=%d, col=%d::%s',
+                strtolower($violation->getSeverityAsString()),
+                $violation->getFilename(),
+                $violation->getLine(),
+                $violation->getColumn(),
+                $violation->getReason()
+            ));
+        }
+    }
+}

--- a/src/Reporter/GithubActionReporter.php
+++ b/src/Reporter/GithubActionReporter.php
@@ -7,18 +7,38 @@ use Symfony\Component\Console\Output\OutputInterface;
 class GithubActionReporter implements ReporterInterface
 {
     /**
+     * @see https://github.com/actions/toolkit/blob/5e5e1b7aacba68a53836a34db4a288c3c1c1585b/packages/core/src/command.ts#L80-L85
+     */
+    private const ESCAPED_DATA = [
+        '%' => '%25',
+        "\r" => '%0D',
+        "\n" => '%0A',
+    ];
+
+    /**
+     * @see https://github.com/actions/toolkit/blob/5e5e1b7aacba68a53836a34db4a288c3c1c1585b/packages/core/src/command.ts#L87-L94
+     */
+    private const ESCAPED_PROPERTIES = [
+        '%' => '%25',
+        "\r" => '%0D',
+        "\n" => '%0A',
+        ':' => '%3A',
+        ',' => '%2C',
+    ];
+
+    /**
      * {@inheritdoc}
      */
     public function report(OutputInterface $output, array $violations)
     {
-        foreach ($violations as $violation) {
+        foreach ($violations as $key => $violation) {
             $output->writeln(sprintf(
-                '::%s file=%s, line=%d, col=%d::%s',
+                '::%s file=%s, line=%s, col=%s::%s',
                 strtolower($violation->getSeverityAsString()),
-                $violation->getFilename(),
-                $violation->getLine(),
-                $violation->getColumn(),
-                $violation->getReason()
+                strtr($violation->getFilename(), self::ESCAPED_PROPERTIES),
+                strtr($violation->getLine() ?? 1, self::ESCAPED_PROPERTIES),
+                strtr($violation->getColumn() ?? 0, self::ESCAPED_PROPERTIES),
+                strtr($violation->getReason(), self::ESCAPED_DATA)
             ));
         }
     }

--- a/tests/Reporter/CsvReporterTest.php
+++ b/tests/Reporter/CsvReporterTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace FriendsOfTwig\Twigcs\Tests\Reporter;
+
+use FriendsOfTwig\Twigcs\Reporter\CsvReporter;
+use FriendsOfTwig\Twigcs\Validator\Violation;
+use PHPUnit\Framework\TestCase;
+
+class CsvReporterTest extends TestCase
+{
+    public function testReport()
+    {
+        $reporter = new CsvReporter();
+        $output = $this
+            ->getMockBuilder('Symfony\Component\Console\Output\ConsoleOutput')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $output
+            ->expects($this->once())
+            ->method('writeln')
+            ->with('template.twig:10:20: error - You are not allowed to do that.')
+        ;
+
+        $reporter->report($output, [
+            new Violation('template.twig', 10, 20, 'You are not allowed to do that.'),
+        ]);
+    }
+}

--- a/tests/Reporter/CsvReporterTest.php
+++ b/tests/Reporter/CsvReporterTest.php
@@ -20,7 +20,7 @@ class CsvReporterTest extends TestCase
         $output
             ->expects($this->once())
             ->method('writeln')
-            ->with('template.twig:10:20: error - You are not allowed to do that.')
+            ->with('template.twig;10;20;error - You are not allowed to do that.')
         ;
 
         $reporter->report($output, [

--- a/tests/Reporter/GithubActionReporterTest.php
+++ b/tests/Reporter/GithubActionReporterTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace FriendsOfTwig\Twigcs\Tests\Reporter;
+
+use FriendsOfTwig\Twigcs\Reporter\GithubActionReporter;
+use FriendsOfTwig\Twigcs\Validator\Violation;
+use PHPUnit\Framework\TestCase;
+
+class GithubActionReporterTest extends TestCase
+{
+    public function testReport()
+    {
+        $reporter = new GithubActionReporter();
+        $output = $this
+            ->getMockBuilder('Symfony\Component\Console\Output\ConsoleOutput')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $output
+            ->expects($this->once())
+            ->method('writeln')
+            ->with('::error file=template.twig, line=10, col=20::You are not allowed to do that.')
+        ;
+
+        $reporter->report($output, [
+            new Violation('template.twig', 10, 20, 'You are not allowed to do that.'),
+        ]);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Jimmy ESCRICH <jescrich@ruedesvignerons.com>

Due to #146 I hadded an reporter for githubAction : 

```
❯ bin/twigcs --reporter=githubAction
::warning file=tests/data/config/local/a.html.twig, line=1, col=8::Unused variable "foo".
::error file=tests/data/config/local/a.html.twig, line=2, col=2::A tag statement should start with 1 space.
::warning file=tests/data/basepaths/a/bad.html.twig, line=1, col=8::Unused variable "foo".
::warning file=tests/data/basepaths/b/bad.html.twig, line=1, col=8::Unused variable "foo".
::error file=tests/data/syntax_error/syntax_errors.html.twig, line=1, col=17::Unexpected "}".
::error file=tests/data/exclusion/bad/errors.html.twig, line=1, col=2::A print statement should start with 1 space.
::error file=tests/data/exclusion/bad/errors.html.twig, line=1, col=13::There should be 0 space between the closing parenthese and its content.
::warning file=tests/data/exclusion/bad/mixed.html.twig, line=1, col=7::Unused variable "foo".
::error file=tests/data/exclusion/bad/mixed.html.twig, line=2, col=2::A print statement should start with 1 space.
::error file=tests/data/exclusion/bad/mixed.html.twig, line=2, col=13::There should be 0 space between the closing parenthese and its content.
::warning file=tests/data/exclusion/bad/warning.html.twig, line=1, col=7::Unused variable "foo".
```

About comment by @stof , I think it's not realy important to have an option for human readable logs. We have a lot of reporters and it's just an option. Are you ok with that ?