### PR TITLE
Issue #155 : Correct error on operator = is in parenthesis

### DIFF
--- a/src/RegEngine/RulesetBuilder.php
+++ b/src/RegEngine/RulesetBuilder.php
@@ -262,8 +262,6 @@ class RulesetBuilder
 
     public function build(): array
     {
-        $expr = [];
-
         $tags = self::using(self::TAGS_VARS, [
             ['<➀use $ with &➁>', $this->argTag()->delegate('$', 'expr')->delegate('&', 'imports')],
             ['<➀use $➁>', $this->argTag()->delegate('$', 'expr')],
@@ -587,7 +585,7 @@ class RulesetBuilder
                 ->delegate('$', 'expr')
                 ->delegate('%', 'argsList'),
             ],
-            ['@➀=(?!>)➁$', Handler::create()
+            ['@➀=(?![>=])➁$', Handler::create()
                 ->enforceSize('➀', $this->config['named_args']['before_='], 'There should be %quantity% space(s) before the "=" in the named arguments list.')
                 ->enforceSize('➁', $this->config['named_args']['after_='], 'There should be %quantity% space(s) after the "=" in the named arguments list.')
                 ->delegate('$', 'expr'),

--- a/src/RegEngine/RulesetBuilder.php
+++ b/src/RegEngine/RulesetBuilder.php
@@ -578,7 +578,7 @@ class RulesetBuilder
 
         $argsList = $this->using(self::LIST_VARS, [
             [' ', Handler::create()->enforceSize(' ', $this->config['empty_list_whitespaces'], 'Empty list should have %quantity% whitespace(s).')],
-            ['@➀=➁$➂,➃%', Handler::create()
+            ['@➀=(?![>])➁$➂,➃%', Handler::create()
                 ->enforceSize('➀', $this->config['named_args']['before_='], 'There should be %quantity% space(s) before the "=" in the named arguments list.')
                 ->enforceSize('➁', $this->config['named_args']['after_='], 'There should be %quantity% space(s) after the "=" in the named arguments list.')
                 ->enforceSize('➂', $this->config['named_args']['after_value'], 'There should be %quantity% space(s) after the value in the named arguments list.')

--- a/tests/Twig3FunctionalTest.php
+++ b/tests/Twig3FunctionalTest.php
@@ -25,7 +25,10 @@ class Twig3FunctionalTest extends TestCase
         $validator = new Validator();
 
         $violations = $validator->validate(new Official(3), $lexer->tokenize(new Source($expression, 'src', 'src.html.twig')));
-        $this->assertCount(0, $validator->getCollectedData()[RegEngineRule::class]['unrecognized_expressions'] ?? []);
+        $this->assertCount(
+            0,
+            $validator->getCollectedData()[RegEngineRule::class]['unrecognized_expressions'] ?? []
+        );
 
         if ($expectedViolation) {
             $this->assertCount(1, $violations, sprintf("There should be one violation in:\n %s", $expression));
@@ -272,6 +275,7 @@ class Twig3FunctionalTest extends TestCase
 
             // Arrow functions
             ['{% for a in b|filter(c => c > 10) %}{{ a }}', null],
+            ['{{ numbers|reduce((carry, v) => carry + v, 10) }}', null],
             ['{% for a in b|filter(c  => c > 10) %}{{ a }}', 'There should be 1 space between the arrow and its arguments.'],
             ['{% for a in b|filter(c =>  c > 10) %}{{ a }}', 'There should be 1 space between the arrow and its body.'],
             ['{% for a in b|filter((c ) => c > 10) %}{{ a }}', 'There should be 0 space between the closing parenthese and its content.'],

--- a/tests/Twig3FunctionalTest.php
+++ b/tests/Twig3FunctionalTest.php
@@ -146,6 +146,7 @@ class Twig3FunctionalTest extends TestCase
             ['{{ foo <=> -1 }}', null],
             ['{{ foo  <=> -1 }}', 'There should be 1 space between the "<=>" operator and its left operand.'],
             ['{{ foo <=>  -1 }}', 'There should be 1 space between the "<=>" operator and its right operand.'],
+            ["{{ (test == 3) }}", null],
             ['{{ -1 }}', null],
             ['{{ -10 }}', null],
             ['{{ (-10) }}', null],


### PR DESCRIPTION
Then the operator `==` is in parenthesis, the `unrecognized_expressions` is used. So we need to escape the verification instead of `=>` operator

Closed #155 
Closed #157 

Signed-off-by: Jimmy ESCRICH <jescrich@ruedesvignerons.com>