### PR TITLE
Fix RulesetConfigurator::setNamedArgsSpacingPattern() arg type

### DIFF
--- a/src/RegEngine/RulesetConfigurator.php
+++ b/src/RegEngine/RulesetConfigurator.php
@@ -397,7 +397,7 @@ class RulesetConfigurator
         return $this;
     }
 
-    public function setNamedArgsSpacingPattern(int $namedArgsSpacingPattern): self
+    public function setNamedArgsSpacingPattern(string $namedArgsSpacingPattern): self
     {
         $this->namedArgsSpacingPattern = $namedArgsSpacingPattern;
 


### PR DESCRIPTION
`$namedArgsSpacingPattern` is a string, it cannot be overrided as `RulesetConfigurator::setNamedArgsSpacingPattern()` method expect an integer as arg.