### PR TITLE
Fix inline list var rule

### DIFF
--- a/src/RegEngine/RulesetBuilder.php
+++ b/src/RegEngine/RulesetBuilder.php
@@ -646,7 +646,7 @@ class RulesetBuilder
                 ->enforceSize(' ', $this->config['hash']['after_key'], 'There should be %quantity% space(s) between the key and ":".')
                 ->enforceSize('_', $this->config['hash']['before_value'], 'There should be %quantity% space(s) between ":" and the value.')
                 ->enforceSize('•', $this->config['hash']['after_value'], 'There should be %quantity% space(s) between the value and the following ",".')
-                ->enforceSpaceOrLineBreak('…', $this->config['hash']['after_coma'], 'There should be %quantity% space(s) between the , and the following hash key.'),
+                //->enforceSpaceOrLineBreak('…', $this->config['hash']['after_coma'], 'There should be %quantity% space(s) between the , and the following hash key.'),
             ],
             ['@ :_$,', Handler::create()
                 ->delegate('$', 'expr')

--- a/src/RegEngine/RulesetBuilder.php
+++ b/src/RegEngine/RulesetBuilder.php
@@ -645,7 +645,8 @@ class RulesetBuilder
                 ->delegate('%', 'hash')
                 ->enforceSize(' ', $this->config['hash']['after_key'], 'There should be %quantity% space(s) between the key and ":".')
                 ->enforceSize('_', $this->config['hash']['before_value'], 'There should be %quantity% space(s) between ":" and the value.')
-                ->enforceSize('•', $this->config['hash']['after_value'], 'There should be %quantity% space(s) between the value and the following ",".'),
+                ->enforceSize('•', $this->config['hash']['after_value'], 'There should be %quantity% space(s) between the value and the following ",".')
+                ->enforceSpaceOrLineBreak('…', $this->config['hash']['after_coma'], 'There should be %quantity% space(s) between the , and the following hash key.'),
             ],
             ['@ :_$,', Handler::create()
                 ->delegate('$', 'expr')

--- a/src/RegEngine/RulesetBuilder.php
+++ b/src/RegEngine/RulesetBuilder.php
@@ -646,7 +646,7 @@ class RulesetBuilder
                 ->enforceSize(' ', $this->config['hash']['after_key'], 'There should be %quantity% space(s) between the key and ":".')
                 ->enforceSize('_', $this->config['hash']['before_value'], 'There should be %quantity% space(s) between ":" and the value.')
                 ->enforceSize('•', $this->config['hash']['after_value'], 'There should be %quantity% space(s) between the value and the following ",".')
-                //->enforceSpaceOrLineBreak('…', $this->config['hash']['after_coma'], 'There should be %quantity% space(s) between the , and the following hash key.'),
+                ->enforceSpaceOrLineBreak('…', $this->config['hash']['after_coma'], 'There should be %quantity% space(s) between the , and the following hash key.'),
             ],
             ['@ :_$,', Handler::create()
                 ->delegate('$', 'expr')

--- a/tests/Twig3FunctionalTest.php
+++ b/tests/Twig3FunctionalTest.php
@@ -91,10 +91,15 @@ class Twig3FunctionalTest extends TestCase
 
             // Put one (and only one) space after the : sign in hashes and , in arrays and hashes:
             ['{{ {foo: 1} }}', null],
+            ['{{ {"foo": 1} }}', null],
             ['{{ {  foo: 1} }}', 'There should be 0 space before the hash values.'],
+            ['{{ {  "foo": 1} }}', 'There should be 0 space before the hash values.'],
             ['{{ {foo: 1 } }}', 'There should be 0 space after the hash values.'],
+            ['{{ {"foo": 1 } }}', 'There should be 0 space after the hash values.'],
             ['{{ {foo:  1} }}', 'There should be 1 space between ":" and the value.'],
+            ['{{ {"foo":  1} }}', 'There should be 1 space between ":" and the value.'],
             ['{{ {foo: 1,   bar: 2} }}', 'There should be 1 space between the , and the following hash key.'],
+            ['{{ {"foo": 1,   "bar": 2} }}', 'There should be 1 space between the , and the following hash key.'],
             ['{{ [1, 2, 3] }}', null],
             ["{{ [1,\n2] }}", null],
             ['{{ {hash: ","} }}', null],
@@ -300,6 +305,15 @@ class Twig3FunctionalTest extends TestCase
                 },
             } }}', null],
             ['{{ {
+                "A": "",
+                "B": {
+                    "foo": {
+                        "A": 1
+                    },
+                    "bar": baz
+                },
+            } }}', null],
+            ['{{ {
                 A: "",
                 B:  {
                     foo: {
@@ -309,12 +323,30 @@ class Twig3FunctionalTest extends TestCase
                 },
             } }}', 'There should be 1 space between ":" and the value.'],
             ['{{ {
+                "A": "",
+                "B":  {
+                    "foo": {
+                        "A": 1
+                    },
+                    "bar": baz
+                },
+            } }}', 'There should be 1 space between ":" and the value.'],
+            ['{{ {
                 A: "",
                 B: {
                     foo: {
                         A: 1
                     },
                     bar:   baz
+                },
+            } }}', 'There should be 1 space between ":" and the value.'],
+            ['{{ {
+                "A": "",
+                "B": {
+                    "foo": {
+                        "A": 1
+                    },
+                    "bar":   baz
                 },
             } }}', 'There should be 1 space between ":" and the value.'],
 
@@ -372,9 +404,15 @@ class Twig3FunctionalTest extends TestCase
             // Check short object initialization
             ['{% include "foo.html.twig" with {bar, bar} %}', null],
             ['{% include "foo.html.twig" with {bar, bar, foo: 1} %}', null],
+            ['{% include "foo.html.twig" with {bar, bar, "foo": 1} %}', null],
             ['{% include "foo.html.twig" with {foo: 1, bar, bar} %}', null],
+            ['{% include "foo.html.twig" with {"foo": 1, bar, bar} %}', null],
             ['{% include "foo.html.twig" with {bar   , bar} %}', 'There should be 0 space between the value and the following ",".'],
+            ['{% include "foo.html.twig" with {foo: 1 , bar} %}', 'There should be 0 space between the value and the following ",".'],
+            ['{% include "foo.html.twig" with {"foo": 1 , bar} %}', 'There should be 0 space between the value and the following ",".'],
             ['{% include "foo.html.twig" with {bar,    bar} %}', 'There should be 1 space between the , and the following hash key.'],
+            ['{% include "foo.html.twig" with {foo: 1,    bar} %}', 'There should be 1 space between the , and the following hash key.'],
+            ['{% include "foo.html.twig" with {"foo": 1,    bar} %}', 'There should be 1 space between the , and the following hash key.'],
 
             // Check regression of https://github.com/friendsoftwig/twigcs/issues/62
             ['{%~ if foo ~%}', null],


### PR DESCRIPTION
There is currently different rules for inline list vars whether they are surrounded by quotes or not.