### PR TITLE
Fix unused variable

### DIFF
--- a/src/Rule/UnusedVariable.php
+++ b/src/Rule/UnusedVariable.php
@@ -46,6 +46,12 @@ class UnusedVariable extends AbstractRule implements RuleInterface
                 switch ($blockType) {
                     case 'embed':
                     case 'include':
+                        $templateName = $tokens->look(4);
+
+                        if (Token::NAME_TYPE === $templateName->getType()) { // {% import varName ... %}
+                            $scope->use($templateName->getValue());
+                        }
+
                         if ('with' === $tokens->look(6)->getValue()) {
                             $this->skip($tokens, 8);
                         } else {

--- a/tests/Twig3FunctionalTest.php
+++ b/tests/Twig3FunctionalTest.php
@@ -227,6 +227,7 @@ class Twig3FunctionalTest extends TestCase
             ['{% set foo = 1 %}{{ foo }}', null],
             ['{% set foo %}1{% endset %}{{ foo }}', null],
             ['{% set foo %}1{% endset %}{{ include("foo.html.twig", {foo: foo}) }}', null],
+            ['{% set template = \'foo.html.twig\' %}{% include template %}', null],
 
             // import spacing
             ['{% import  "foo.html.twig" as foo %}{{ foo() }}', 'There should be 1 space before the source.'],


### PR DESCRIPTION
When the variable is used as template in an include tag it triggers a warning of unused variable.

Not sure if it's the proper fix BTW.