### PR TITLE
Allow configuring `display` from config file and honor config file options

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -15,6 +15,7 @@ class Config implements ConfigInterface
     private $reporter = 'console';
     private $ruleset = Official::class;
     private $specificRulesets = [];
+    private $display = ConfigInterface::DISPLAY_ALL;
 
     public function __construct($name = 'default')
     {
@@ -143,6 +144,18 @@ class Config implements ConfigInterface
     public function setSpecificRulesets(array $ruleSet): self
     {
         $this->specificRulesets = $ruleSet;
+
+        return $this;
+    }
+
+    public function getDisplay(): string
+    {
+        return $this->display;
+    }
+
+    public function setDisplay(string $display): self
+    {
+        $this->display = $display;
 
         return $this;
     }

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -2,13 +2,16 @@
 
 namespace FriendsOfTwig\Twigcs\Config;
 
-use Symfony\Component\Finder\Finder;
-
 /**
  * Special thanks to https://github.com/c33s/twigcs/ which this feature was inspired from.
+ *
+ * @method string getDisplay()
  */
 interface ConfigInterface
 {
+    public const DISPLAY_BLOCKING = 'blocking';
+    public const DISPLAY_ALL = 'all';
+
     /**
      * Returns the name of the configuration.
      *

--- a/src/Config/ConfigResolver.php
+++ b/src/Config/ConfigResolver.php
@@ -44,6 +44,7 @@ final class ConfigResolver
         'exclude' => [],
         'config' => null,
         'twig-version' => null,
+        'display' => null,
     ];
 
     private $finders;
@@ -169,6 +170,19 @@ final class ConfigResolver
             default:
                 throw new \InvalidArgumentException('Invalid severity limit provided.');
         }
+    }
+
+    public function getDisplay(): string
+    {
+        if (null !== $this->options['display']) {
+            return $this->options['display'];
+        }
+
+        if (!method_exists($this->getConfig(), 'getDisplay')) {
+            return ConfigInterface::DISPLAY_ALL;
+        }
+
+        return $this->getConfig()->getDisplay();
     }
 
     public function getConfig(): ConfigInterface

--- a/tests/Console/LintCommandTest.php
+++ b/tests/Console/LintCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace FriendsOfTwig\Twigcs\Tests\Console;
 
+use FriendsOfTwig\Twigcs\Config\ConfigInterface;
 use FriendsOfTwig\Twigcs\Console\LintCommand;
 use FriendsOfTwig\Twigcs\Container;
 use FriendsOfTwig\Twigcs\TwigPort\SyntaxError;
@@ -13,7 +14,7 @@ class LintCommandTest extends TestCase
     /** @var CommandTester */
     private $commandTester;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $container = new Container();
         $command = new LintCommand();
@@ -113,7 +114,7 @@ class LintCommandTest extends TestCase
         $this->commandTester->execute([
             'paths' => ['tests/data/exclusion/bad/mixed.html.twig'],
             '--severity' => 'error',
-            '--display' => LintCommand::DISPLAY_BLOCKING,
+            '--display' => ConfigInterface::DISPLAY_BLOCKING,
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -130,7 +131,7 @@ class LintCommandTest extends TestCase
         $this->commandTester->execute([
             'paths' => ['tests/data/exclusion/bad/mixed.html.twig'],
             '--severity' => 'error',
-            '--display' => LintCommand::DISPLAY_ALL,
+            '--display' => ConfigInterface::DISPLAY_ALL,
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -148,7 +149,7 @@ class LintCommandTest extends TestCase
         $this->commandTester->execute([
             'paths' => ['tests/data/syntax_error/syntax_errors.html.twig'],
             '--severity' => 'error',
-            '--display' => LintCommand::DISPLAY_ALL,
+            '--display' => ConfigInterface::DISPLAY_ALL,
             '--throw-syntax-error' => true,
         ]);
 
@@ -161,7 +162,7 @@ class LintCommandTest extends TestCase
         $this->commandTester->execute([
             'paths' => ['tests/data/syntax_error/syntax_errors.html.twig'],
             '--severity' => 'error',
-            '--display' => LintCommand::DISPLAY_ALL,
+            '--display' => ConfigInterface::DISPLAY_ALL,
             '--throw-syntax-error' => false,
         ]);
 
@@ -177,7 +178,7 @@ class LintCommandTest extends TestCase
         $this->commandTester->execute([
             'paths' => ['tests/data/syntax_error/syntax_errors.html.twig'],
             '--severity' => 'error',
-            '--display' => LintCommand::DISPLAY_ALL,
+            '--display' => ConfigInterface::DISPLAY_ALL,
         ]);
 
         $output = $this->commandTester->getDisplay();
@@ -221,6 +222,20 @@ l.1 c.8 : WARNING Unused variable "foo".
 tests/data/syntax_error/syntax_errors.html.twig
 l.1 c.17 : ERROR Unexpected "}".
 3 violation(s) found', $output);
+    }
+
+    public function testConfigFileWithDisplayAndSeverity()
+    {
+        $this->commandTester->execute([
+            '--config' => 'tests/data/config/external/.twig_cs_with_display_blocking.dist',
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $statusCode = $this->commandTester->getStatusCode();
+        $this->assertSame($statusCode, 1);
+        $this->assertStringContainsString('tests/data/syntax_error/syntax_errors.html.twig
+l.1 c.17 : ERROR Unexpected "}".
+1 violation(s) found', $output);
     }
 
     public function testConfigFileSamePathWithRulesetOverrides()

--- a/tests/data/config/external/.twig_cs_with_display_blocking.dist
+++ b/tests/data/config/external/.twig_cs_with_display_blocking.dist
@@ -1,0 +1,11 @@
+<?php
+
+$finder = FriendsOfTwig\Twigcs\Finder\TemplateFinder::create()
+    ->in(__DIR__.'/../../syntax_error')
+;
+
+return \FriendsOfTwig\Twigcs\Config\Config::create()
+    ->addFinder($finder)
+    ->setSeverity('error')
+    ->setDisplay('blocking')
+;


### PR DESCRIPTION
Closes https://github.com/friendsoftwig/twigcs/issues/176

The `severity` argument was required for the cli command and it had `warning` as default value.

https://github.com/friendsoftwig/twigcs/blob/ba9947166b563fdac453f65611eca4fe9736b3cc/src/Console/LintCommand.php#L26

The problem is that this value is passed to `ConfigResolver`:

https://github.com/friendsoftwig/twigcs/blob/ba9947166b563fdac453f65611eca4fe9736b3cc/src/Console/LintCommand.php#L39-L47

where these options are set and then trying to get the `severity`:

https://github.com/friendsoftwig/twigcs/blob/ba9947166b563fdac453f65611eca4fe9736b3cc/src/Config/ConfigResolver.php#L149-L156

it is always `warning` because was set by the cli (even if it is not passed to the cli) instead of using the one from the config file (if exists).
