### PR TITLE
Fix PHP 8.1 deprecation errors

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest, macos-latest ]
-        php-versions: [ '7.3', '7.4', '8.0' ]
+        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -20,7 +20,7 @@ class Lexer extends TwigLexer
     protected function lexExpression()
     {
         // collect whitespaces and new lines
-        if (preg_match('/\s+/A', $this->code, $match, null, $this->cursor)) {
+        if (preg_match('/\s+/A', $this->code, $match, 0, $this->cursor)) {
             if ("\n" === $match[0]) {
                 $emptyLines = [''];
             } else {
@@ -41,7 +41,7 @@ class Lexer extends TwigLexer
 
     protected function lexBlock()
     {
-        if (empty($this->brackets) && preg_match($this->regexes['lex_block'], $this->code, $match, null, $this->cursor)) {
+        if (empty($this->brackets) && preg_match($this->regexes['lex_block'], $this->code, $match, 0, $this->cursor)) {
             // Collect whitespaces in end blocks
             if (preg_match('/^(\s+)/', $match[0], $spaces)) {
                 $this->pushToken(Token::WHITESPACE_TYPE, $spaces[0]);
@@ -57,7 +57,7 @@ class Lexer extends TwigLexer
 
     protected function lexVar()
     {
-        if (empty($this->brackets) && preg_match($this->regexes['lex_var'], $this->code, $match, null, $this->cursor)) {
+        if (empty($this->brackets) && preg_match($this->regexes['lex_var'], $this->code, $match, 0, $this->cursor)) {
             // Collect whitespaces in end blocks
             if (preg_match('/^(\s+)/', $match[0], $spaces)) {
                 $this->pushToken(Token::WHITESPACE_TYPE, $spaces[0]);


### PR DESCRIPTION
While running my test suite on PHP 8.1 RC3, I encountered following errors.
The default value of `$flags` param is now 0.

```
Deprecated: preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated in /var/glpi/vendor/friendsoftwig/twigcs/src/Lexer.php on line 23

Deprecated: preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated in /var/glpi/vendor/friendsoftwig/twigcs/src/Lexer.php on line 44

Deprecated: preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated in /var/glpi/vendor/friendsoftwig/twigcs/src/Lexer.php on line 60
```