### PR TITLE
Mark the value of the display option as required

### DIFF
--- a/src/Console/LintCommand.php
+++ b/src/Console/LintCommand.php
@@ -31,7 +31,7 @@ class LintCommand extends ContainerAwareCommand
             ->addArgument('paths', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'The path to scan for twig files.', null)
             ->addOption('twig-version', 't', InputOption::VALUE_REQUIRED, 'The major version of twig to use.', 3)
             ->addOption('exclude', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Excluded folder of path.', [])
-            ->addOption('severity', 's', InputOption::VALUE_OPTIONAL, 'The maximum allowed error level.')
+            ->addOption('severity', 's', InputOption::VALUE_REQUIRED, 'The maximum allowed error level.')
             ->addOption('reporter', 'r', InputOption::VALUE_REQUIRED, 'The reporter to use.')
             ->addOption('display', 'd', InputOption::VALUE_REQUIRED, 'The violations to display, "'.ConfigInterface::DISPLAY_ALL.'" or "'.ConfigInterface::DISPLAY_BLOCKING.'".')
             ->addOption('throw-syntax-error', 'e', InputOption::VALUE_NONE, 'Throw syntax error when a template contains an invalid token.')

--- a/src/Console/LintCommand.php
+++ b/src/Console/LintCommand.php
@@ -33,7 +33,7 @@ class LintCommand extends ContainerAwareCommand
             ->addOption('exclude', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Excluded folder of path.', [])
             ->addOption('severity', 's', InputOption::VALUE_OPTIONAL, 'The maximum allowed error level.')
             ->addOption('reporter', 'r', InputOption::VALUE_REQUIRED, 'The reporter to use.')
-            ->addOption('display', 'd', InputOption::VALUE_OPTIONAL, 'The violations to display, "'.ConfigInterface::DISPLAY_ALL.'" or "'.ConfigInterface::DISPLAY_BLOCKING.'".')
+            ->addOption('display', 'd', InputOption::VALUE_REQUIRED, 'The violations to display, "'.ConfigInterface::DISPLAY_ALL.'" or "'.ConfigInterface::DISPLAY_BLOCKING.'".')
             ->addOption('throw-syntax-error', 'e', InputOption::VALUE_NONE, 'Throw syntax error when a template contains an invalid token.')
             ->addOption('ruleset', null, InputOption::VALUE_REQUIRED, 'Ruleset class to use')
             ->addOption('config', null, InputOption::VALUE_REQUIRED, 'Config file to use', null)


### PR DESCRIPTION
Using the display option without a value does not make sense, and is not handled by the code anyway.

See https://github.com/friendsoftwig/twigcs/pull/177/files#r728771645