### PR TITLE
Fix: Remove Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: php
-php:
-  - 7.3
-  - 7.4
-  - 8.0
-install:
-  - composer --prefer-source -n install


### PR DESCRIPTION
This pull request

- [x] removes the Travis CI configuration

💁‍♂️ Looks like we are using GitHub Actions instead, see [`.github/workflows/ci-tests.yaml`](https://github.com/friendsoftwig/twigcs/blob/035af79b0fabbab1fc6b8e5698ead1f80e25c4ec/.github/workflows/ci-tests.yaml)