### PR TITLE
Fix: Do not prefer to install from source

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -25,7 +25,7 @@ jobs:
           tools: phpunit
 
       - name: Install dependencies
-        run: composer --prefer-source -n install
+        run: composer -n install
 
       - name: Launch test
         run: bin/phpunit


### PR DESCRIPTION
This pull request

- [x] stops using the `--prefer-source` option when installing dependencies with `composer`