### PR TITLE
Fix: Do not bother installing `phpunit` with `shivammathur/setup-php`

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -22,7 +22,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit
 
       - name: Install dependencies
         run: composer --prefer-source -n install


### PR DESCRIPTION
This pull request

- [x] stops installing `phpunit` with `shivammathur/setup-php`

💁‍♂️ It is a direct dependency that we currently install with `composer`.