### PR TITLE
Fix: Run workflow on push and pull_request events

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,15 +1,8 @@
 name: "Integrate"
 
 on:
-  pull_request:
-    types:
-      - "opened"
-      - "reopened"
-  push:
-  release:
-    types:
-      - "opened"
-      - "reopened"
+  pull_request: null
+  push: null
 
 jobs:
   tests:


### PR DESCRIPTION
This pull request

- [x] runs the integrate workflow on all `push` and `pull_request` events

Somewhat related to #178.

💁‍♂️ For reference, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows.