### PR TITLE
Fix: Do not bother running workflow on macos-latest

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -8,14 +8,10 @@ jobs:
   tests:
     name: "Tests"
 
-    runs-on: "${{ matrix.operating-system }}"
+    runs-on: "ubuntu-latest"
 
     strategy:
       matrix:
-        operating-system:
-          - "ubuntu-latest"
-          - "macos-latest"
-
         php-version:
           - "7.4"
           - "8.0"


### PR DESCRIPTION
This pull request

- [x] stops running the integrate workflow on `macos-latest`

💁‍♂️ What's the point?