### PR TITLE
Fix: Do not configure `bin` directory

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -34,4 +34,4 @@ jobs:
         run: "composer -n install"
 
       - name: "Run tests with phpunit/phpunit"
-        run: "bin/phpunit"
+        run: "vendor/bin/phpunit"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 /vendor/
-/bin/
-!/bin/twigcs
 composer.lock
 twigcs.phar
 twigcs.phar.asc

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,6 @@
             "FriendsOfTwig\\Twigcs\\Tests\\": "tests/"
         }
     },
-    "config": {
-        "bin-dir": "bin"
-    },
     "bin": [
         "bin/twigcs"
     ]


### PR DESCRIPTION
This pull request

- [x] stops configuring the `bin` directory for `composer`