### PR TITLE
Enhancement: Use `--ansi` option

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -49,7 +49,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
 
       - name: "Install dependencies with composer"
-        run: "composer install --no-progress"
+        run: "composer install --ansi --no-progress"
 
       - name: "Run tests with phpunit/phpunit"
         run: "vendor/bin/phpunit"


### PR DESCRIPTION
This pull request

- [x] uses the `--ansi` option when installing dependencies with `composer` on GitHub Actions