### PR TITLE
Fix: Require `phpunit/phpunit:^9.5.20`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/finder": "^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.0"
+        "phpunit/phpunit": "^9.5.20"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request

- [x] requires `phpunit/phpunit:^9.5.20`

💁‍♂️ It supports PHP 7.3 onwards, so there is no need to use `phpunit/phpunit:^8.0.0`.