### PR TITLE
Enhancement: Validate `box.json.dist` before compiling Phar

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -110,6 +110,9 @@ jobs:
       - name: "Install dependencies with composer"
         run: "composer install --ansi --no-progress"
 
+      - name: "Validate box.json.dist with humbug/box"
+        run: ".phive/box validate"
+
       - name: "Compile twigcs.phar with humbug/box"
         run: ".phive/box compile"
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ help: ## Displays this list of targets with descriptions
 
 .PHONY: phar
 phar: vendor ## Compiles a phar with humbug/box
+	.phive/box validate
 	.phive/box build
 	php twigcs.phar --version
 

--- a/box.json.dist
+++ b/box.json.dist
@@ -1,6 +1,4 @@
 {
-    "stub": true,
-    "main":  "bin/twigcs",
     "directories": ["src", "vendor"],
     "git-version": "__VERSION__",
     "output": "twigcs.phar",


### PR DESCRIPTION
This pull request

- [x] validates `box.json.dist` before compiling Phar
- [x] fixes validation errors