### PR TITLE
Fix: Do not install development dependencies when compiling Phar

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -108,7 +108,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
 
       - name: "Install dependencies with composer"
-        run: "composer install --ansi --no-progress"
+        run: "composer install --ansi --no-dev --no-progress"
 
       - name: "Validate box.json.dist with humbug/box"
         run: ".phive/box validate"

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,12 @@ help: ## Displays this list of targets with descriptions
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: phar
-phar: vendor ## Compiles a phar with humbug/box
+phar: ## Compiles a phar with humbug/box
+	composer install --no-dev --no-progress
 	.phive/box validate
 	.phive/box build
 	php twigcs.phar --version
+	composer install --no-progress
 
 .PHONY: static-code-analysis
 static-code-analysis: vendor ## Runs a static code analysis with vimeo/psalm


### PR DESCRIPTION
This pull request

- [x] stops installing development dependencies before compiling the Phar