### PR TITLE
Fix: Throw `RuntimeException` when service has not been registered for key

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -52,8 +52,15 @@ class Container extends \ArrayObject
         };
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     public function get(string $key)
     {
+        if (!$this->offsetExists($key)) {
+            throw new \RuntimeException(sprintf('A service with the identifier "%s" has not been registered.', $key));
+        }
+
         return call_user_func($this[$key]);
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfTwig\Twigcs\Tests;
+
+use FriendsOfTwig\Twigcs;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \FriendsOfTwig\Twigcs\Container
+ */
+final class ContainerTest extends Framework\TestCase
+{
+    public function testGetThrowsRuntimeExceptionWhenServiceHasNotBeenRegisteredForKey(): void
+    {
+        $key = 'foo';
+
+        $container = new Twigcs\Container();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            'A service with the identifier "%s" has not been registered.',
+            $key
+        ));
+
+        $container->get($key);
+    }
+}


### PR DESCRIPTION
This pull request

- [x] adjusts the `Container` to throw a `RuntimeException` when a service has not been registered for a specific key