### PR TITLE
Fix: Add language identifier for code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ return \FriendsOfTwig\Twigcs\Config\Config::create()
 
 Here is a more complex example that uses a chain resolver and a namespaced resolver to handle vendor templates:
 
-```
+```php
 <?php
 
 use FriendsOfTwig\Twigcs\TemplateResolver;


### PR DESCRIPTION
This pull request

- [x] adds an otherwise missing language identifier for a code block