### PR TITLE
Enhancement: Require and use `symfony/phpunit-bridge`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "symfony/finder": "^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.20"
+        "phpunit/phpunit": "^9.5.20",
+        "symfony/phpunit-bridge": "^6.2.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,9 @@
             <directory suffix=".php">src</directory>
         </include>
     </coverage>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,9 @@
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=655"/>
+    </php>
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>tests</directory>


### PR DESCRIPTION
This pull request

- [x] requires `symfony/phpunit-bridge`
- [x] registers `Symfony\Bridge\PhpUnit\SymfonyTestsListener`
- [x] allows 655 deprecations

Related to #258.

💁‍♂️ For reference, see https://symfony.com/doc/current/components/phpunit_bridge.html.
