### PR TITLE
Fix: Declare otherwise dynamically declared property

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=655"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
     <testsuites>
         <testsuite name="Project Test Suite">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1272,8 +1272,7 @@
     </MixedArgument>
   </file>
   <file src="src/Rule/UnusedMacro.php">
-    <MixedArgument occurrences="4">
-      <code>$this-&gt;loader</code>
+    <MixedArgument occurrences="3">
       <code>$token-&gt;getColumn()</code>
       <code>$token-&gt;getLine()</code>
       <code>$token-&gt;getValue()</code>
@@ -1293,16 +1292,9 @@
       <code>getToken</code>
       <code>getValue</code>
     </MixedMethodCall>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;loader</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;loader</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/Rule/UnusedVariable.php">
-    <MixedArgument occurrences="4">
-      <code>$this-&gt;loader</code>
+    <MixedArgument occurrences="3">
       <code>$token-&gt;getColumn()</code>
       <code>$token-&gt;getLine()</code>
       <code>$token-&gt;getValue()</code>
@@ -1322,12 +1314,6 @@
       <code>getToken</code>
       <code>getValue</code>
     </MixedMethodCall>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;loader</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;loader</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/Ruleset/Official.php">
     <MissingPropertyType occurrences="1">

--- a/src/Rule/UnusedMacro.php
+++ b/src/Rule/UnusedMacro.php
@@ -9,6 +9,8 @@ use FriendsOfTwig\Twigcs\TwigPort\TokenStream;
 
 class UnusedMacro extends AbstractRule implements RuleInterface
 {
+    public TemplateResolverInterface $loader;
+
     public function __construct(int $severity, TemplateResolverInterface $loader = null)
     {
         $this->loader = $loader ?: new NullResolver();

--- a/src/Rule/UnusedVariable.php
+++ b/src/Rule/UnusedVariable.php
@@ -9,6 +9,8 @@ use FriendsOfTwig\Twigcs\TwigPort\TokenStream;
 
 class UnusedVariable extends AbstractRule implements RuleInterface
 {
+    public TemplateResolverInterface $loader;
+
     public function __construct(int $severity, TemplateResolverInterface $loader = null)
     {
         $this->loader = $loader ?: new NullResolver();


### PR DESCRIPTION
This pull request

- [x] disallows deprecations
- [x] declares otherwise dynamically declared properties
- [x] runs `make static-code-analysis-baseline`

Fixes #258.
