### PR TITLE
Enhancement: Enable `php_unit_test_class_requires_covers` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -57,6 +57,7 @@ return $config
             'sort_algorithm' => 'alpha',
         ],
         'php_unit_internal_class' => true,
+        'php_unit_test_class_requires_covers' => true,
         'phpdoc_order' => [
             'order' => [
                 'param',


### PR DESCRIPTION
This pull request

- [x] enables the `php_unit_test_class_requires_covers` fixer
- [ ] adds missing `@covers` annotations

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.13.2/doc/rules/php_unit/php_unit_test_class_requires_covers.rst.