### PR TITLE
Fix: Do not abuse `setUp()`

### DIFF
--- a/tests/Functional/Console/LintCommandTest.php
+++ b/tests/Functional/Console/LintCommandTest.php
@@ -14,37 +14,30 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 final class LintCommandTest extends TestCase
 {
-    private CommandTester $commandTester;
-
-    protected function setUp(): void
-    {
-        $container = new Container();
-        $command = new LintCommand();
-        $command->setContainer($container);
-
-        $this->commandTester = new CommandTester($command);
-    }
-
     public function testExecute(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => ['tests/Fixture/exclusion/good'],
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 0);
         $this->assertStringContainsString('No violation found.', $output);
     }
 
     public function testMultipleBasePaths(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => ['tests/Fixture/basepaths/a', 'tests/Fixture/basepaths/b'],
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringStartsWith('tests/Fixture/basepaths/a/bad.html.twig', $output);
         $this->assertStringContainsString("\ntests/Fixture/basepaths/b/bad.html.twig", $output);
@@ -52,75 +45,85 @@ final class LintCommandTest extends TestCase
 
     public function testExecuteWithError(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => ['tests/Fixture/exclusion'],
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringContainsString('ERROR', $output);
     }
 
     public function testExecuteWithIgnoredErrors(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             '--severity' => 'ignore',
             'paths' => ['tests/Fixture/exclusion'],
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 0);
         $this->assertStringContainsString('ERROR', $output);
     }
 
     public function testExecuteWithIgnoredWarnings(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             '--severity' => 'error',
             'paths' => ['tests/Fixture/exclusion/bad/warning.html.twig'],
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 0);
         $this->assertStringContainsString('WARNING', $output);
 
-        $this->commandTester->execute([
+        $commandTester->execute([
             '--severity' => 'error',
             'paths' => ['tests/Fixture/exclusion/bad'],
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringContainsString('WARNING', $output);
     }
 
     public function testExecuteWithExclude(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => ['tests/Fixture/exclusion'],
             '--exclude' => ['bad'],
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 0);
         $this->assertStringContainsString('No violation found.', $output);
     }
 
     public function testErrorsOnlyDisplayBlocking(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => ['tests/Fixture/exclusion/bad/mixed.html.twig'],
             '--severity' => 'error',
             '--display' => ConfigInterface::DISPLAY_BLOCKING,
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringNotContainsString('l.1 c.7 : WARNING Unused variable "foo".', $output);
         $this->assertStringContainsString('l.2 c.2 : ERROR A print statement should start with 1 space.', $output);
@@ -130,14 +133,16 @@ final class LintCommandTest extends TestCase
 
     public function testErrorsDisplayAll(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => ['tests/Fixture/exclusion/bad/mixed.html.twig'],
             '--severity' => 'error',
             '--display' => ConfigInterface::DISPLAY_ALL,
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringContainsString('l.1 c.7 : WARNING Unused variable "foo".', $output);
         $this->assertStringContainsString('l.2 c.2 : ERROR A print statement should start with 1 space.', $output);
@@ -147,29 +152,34 @@ final class LintCommandTest extends TestCase
 
     public function testSyntaxErrorThrow(): void
     {
+        $commandTester = self::commandTester();
+
         $this->expectException(SyntaxError::class);
-        $this->commandTester->execute([
+
+        $commandTester->execute([
             'paths' => ['tests/Fixture/syntax_error/syntax_errors.html.twig'],
             '--severity' => 'error',
             '--display' => ConfigInterface::DISPLAY_ALL,
             '--throw-syntax-error' => true,
         ]);
 
-        $statusCode = $this->commandTester->getStatusCode();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
     }
 
     public function testSyntaxErrorNotThrow(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => ['tests/Fixture/syntax_error/syntax_errors.html.twig'],
             '--severity' => 'error',
             '--display' => ConfigInterface::DISPLAY_ALL,
             '--throw-syntax-error' => false,
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringContainsString('1 violation(s) found', $output);
         $this->assertStringContainsString('l.1 c.17 : ERROR Unexpected "}"', $output);
@@ -177,14 +187,16 @@ final class LintCommandTest extends TestCase
 
     public function testSyntaxErrorNotThrowOmitArgument(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => ['tests/Fixture/syntax_error/syntax_errors.html.twig'],
             '--severity' => 'error',
             '--display' => ConfigInterface::DISPLAY_ALL,
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringContainsString('1 violation(s) found', $output);
         $this->assertStringContainsString('l.1 c.17 : ERROR Unexpected "}"', $output);
@@ -192,13 +204,15 @@ final class LintCommandTest extends TestCase
 
     public function testConfigFileWithoutCliPath(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => null,
             '--config' => 'tests/Fixture/config/external/.twig_cs.dist.php',
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringContainsString('tests/Fixture/basepaths/a/bad.html.twig
 l.1 c.8 : WARNING Unused variable "foo".
@@ -209,13 +223,15 @@ l.1 c.8 : WARNING Unused variable "foo".
 
     public function testConfigFileWithCliPath(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => ['tests/Fixture/syntax_error'],
             '--config' => 'tests/Fixture/config/external/.twig_cs.dist.php',
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringContainsString('tests/Fixture/basepaths/a/bad.html.twig
 l.1 c.8 : WARNING Unused variable "foo".
@@ -228,12 +244,14 @@ l.1 c.17 : ERROR Unexpected "}".
 
     public function testConfigFileWithDisplayAndSeverity(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             '--config' => 'tests/Fixture/config/external/.twig_cs_with_display_blocking.dist.php',
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringContainsString('tests/Fixture/syntax_error/syntax_errors.html.twig
 l.1 c.17 : ERROR Unexpected "}".
@@ -243,13 +261,16 @@ l.1 c.17 : ERROR Unexpected "}".
     public function testConfigFileSamePathWithRulesetOverrides(): void
     {
         chdir(__DIR__.'/../../Fixture/config/local');
-        $this->commandTester->execute([
+
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             'paths' => null,
         ]);
         chdir(__DIR__.'/../../..');
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringContainsString('{
     "failures": 1,
@@ -272,12 +293,14 @@ l.1 c.17 : ERROR Unexpected "}".
 
     public function testUnusedWithFileLoader(): void
     {
-        $this->commandTester->execute([
+        $commandTester = self::commandTester();
+
+        $commandTester->execute([
             '--config' => 'tests/Fixture/config/loaders/.twig_cs.dist.php',
         ]);
 
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
         $this->assertSame($statusCode, 1);
         $this->assertStringContainsString('tests/Fixture/config/loaders/src/embed/child.html.twig
 l.3 c.7 : WARNING Unused variable "unused_child".
@@ -292,5 +315,14 @@ l.3 c.7 : WARNING Unused variable "unused_child".
 tests/Fixture/config/loaders/src/include/parent.html.twig
 l.2 c.7 : WARNING Unused variable "unused_parent".
 6 violation(s) found', $output);
+    }
+
+    private static function commandTester(): CommandTester
+    {
+        $container = new Container();
+        $command = new LintCommand();
+        $command->setContainer($container);
+
+        return new CommandTester($command);
     }
 }

--- a/tests/Functional/CorpusTest.php
+++ b/tests/Functional/CorpusTest.php
@@ -12,26 +12,26 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 final class CorpusTest extends TestCase
 {
-    private CommandTester $commandTester;
+    public function testExecute(): void
+    {
+        $commandTester = self::commandTester();
 
-    protected function setUp(): void
+        $commandTester->execute([
+            'paths' => ['tests/Fixture/valid_corpus'],
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $statusCode = $commandTester->getStatusCode();
+        $this->assertSame($statusCode, 0);
+        $this->assertStringContainsString('No violation found.', $output);
+    }
+
+    private static function commandTester(): CommandTester
     {
         $container = new Container();
         $command = new LintCommand();
         $command->setContainer($container);
 
-        $this->commandTester = new CommandTester($command);
-    }
-
-    public function testExecute(): void
-    {
-        $this->commandTester->execute([
-            'paths' => ['tests/Fixture/valid_corpus'],
-        ]);
-
-        $output = $this->commandTester->getDisplay();
-        $statusCode = $this->commandTester->getStatusCode();
-        $this->assertSame($statusCode, 0);
-        $this->assertStringContainsString('No violation found.', $output);
+        return new CommandTester($command);
     }
 }

--- a/tests/Unit/Rule/ForbiddenFunctionsTest.php
+++ b/tests/Unit/Rule/ForbiddenFunctionsTest.php
@@ -14,24 +14,10 @@ use PHPUnit\Framework\TestCase;
  */
 final class ForbiddenFunctionsTest extends TestCase
 {
-    private TokenStream $tokens;
-
-    protected function setUp(): void
-    {
-        $lexer = new Lexer();
-        $source = new Source(
-            '{{ dump(test) }}{{ dump.test }}',
-            'my/path/file.html.twig',
-            ltrim(str_replace(getcwd(), '', 'my/path/file.html.twig'), '/')
-        );
-
-        $this->tokens = $lexer->tokenize($source);
-    }
-
     public function testCheckWithoutFunctions(): void
     {
         $rule = new ForbiddenFunctions(Violation::SEVERITY_WARNING);
-        $violations = $rule->check($this->tokens);
+        $violations = $rule->check(self::tokenStream());
 
         $this->assertCount(0, $violations);
     }
@@ -39,7 +25,7 @@ final class ForbiddenFunctionsTest extends TestCase
     public function testCheckWithFunctions(): void
     {
         $rule = (new ForbiddenFunctions(Violation::SEVERITY_WARNING))->setFunctions(['dump']);
-        $violations = $rule->check($this->tokens);
+        $violations = $rule->check(self::tokenStream());
 
         $this->assertCount(1, $violations);
         $violation = $violations[0];
@@ -54,8 +40,20 @@ final class ForbiddenFunctionsTest extends TestCase
     public function testCheckWithFunctionsNoEquals(): void
     {
         $rule = (new ForbiddenFunctions(Violation::SEVERITY_WARNING))->setFunctions(['dum']);
-        $violations = $rule->check($this->tokens);
+        $violations = $rule->check(self::tokenStream());
 
         $this->assertCount(0, $violations);
+    }
+
+    private static function tokenStream(): TokenStream
+    {
+        $lexer = new Lexer();
+        $source = new Source(
+            '{{ dump(test) }}{{ dump.test }}',
+            'my/path/file.html.twig',
+            ltrim(str_replace(getcwd(), '', 'my/path/file.html.twig'), '/')
+        );
+
+        return $lexer->tokenize($source);
     }
 }


### PR DESCRIPTION
This pull request

- [x] stops abusing `setUp()`