### PR TITLE
Enhancement: Enable `findUnusedBaselineEntry` option for `vimeo/psalm`

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -6,7 +6,7 @@
     cacheDirectory=".build/psalm"
     errorBaseline="psalm-baseline.xml"
     errorLevel="1"
-    findUnusedBaselineEntry="false"
+    findUnusedBaselineEntry="true"
     findUnusedCode="false"
     findUnusedVariablesAndParams="true"
     resolveFromConfigFile="true"


### PR DESCRIPTION
This pull request

- [x] enables the `findUnusedBaselineEntry` option for `vimeo/psalm`

Follows #307.