### PR TITLE
Fix FatalError "undefined method Symfony\Component\Console\Application::add()" with the 8.0 Symfony Console version

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,7 +1,7 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->exclude('tests/Fixtures/app/cache')
+    ->exclude(['tests/Fixtures/app/cache', 'vendor'])
     ->ignoreDotFiles(false)
     ->in(__DIR__)
 ;

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -19,16 +19,29 @@ class Application extends BaseApplication
 
         $this->container = new Container();
         $command = new LintCommand();
-        $this->add($command);
-        $this->add(new RegDebugCommand());
+        $this->addCommand($command);
+        $this->addCommand(new RegDebugCommand());
 
         $this->setDefaultCommand($command->getName(), $singleCommand);
     }
 
-    public function add(Command $command): ?Command
+    /**
+     * @param callable|Command $command
+     */
+    public function addCommand($command): ?Command
     {
         if ($command instanceof ContainerAwareCommand) {
             $command->setContainer($this->container);
+        }
+
+        // Symfony Console 8.0+ uses addCommand(), earlier versions use add()
+        if (method_exists(BaseApplication::class, 'addCommand')) {
+            return parent::addCommand($command);
+        }
+
+        // For Symfony Console < 8.0, ensure we only pass Command instances
+        if (!$command instanceof Command) {
+            throw new \InvalidArgumentException('Command must be an instance of ' . Command::class . ' for Symfony Console < 8.0');
         }
 
         return parent::add($command);

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -35,8 +35,8 @@ class Application extends BaseApplication
         }
 
         // Symfony Console 8.0+ uses addCommand(), earlier versions use add()
-        // @phpstan-ignore-next-line function.alreadyNarrowedType - method_exists result depends on installed Symfony version
         if (method_exists(BaseApplication::class, 'addCommand')) {
+            // @phpstan-ignore-next-line staticMethod.notFound - addCommand method exists only on Symfony Console 8.0+
             return parent::addCommand($command);
         }
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -35,13 +35,14 @@ class Application extends BaseApplication
         }
 
         // Symfony Console 8.0+ uses addCommand(), earlier versions use add()
+        // @phpstan-ignore-next-line function.alreadyNarrowedType - method_exists result depends on installed Symfony version
         if (method_exists(BaseApplication::class, 'addCommand')) {
             return parent::addCommand($command);
         }
 
         // For Symfony Console < 8.0, ensure we only pass Command instances
         if (!$command instanceof Command) {
-            throw new \InvalidArgumentException('Command must be an instance of ' . Command::class . ' for Symfony Console < 8.0');
+            throw new \InvalidArgumentException('Command must be an instance of '.Command::class.' for Symfony Console < 8.0');
         }
 
         return parent::add($command);

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfTwig\Twigcs\Tests\Unit\Console;
+
+use FriendsOfTwig\Twigcs\Container;
+use FriendsOfTwig\Twigcs\Console\Application;
+use FriendsOfTwig\Twigcs\Console\ContainerAwareCommand;
+use FriendsOfTwig\Twigcs\Console\LintCommand;
+use FriendsOfTwig\Twigcs\Console\RegDebugCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * @internal
+ *
+ * @covers \FriendsOfTwig\Twigcs\Console\Application
+ */
+final class ApplicationTest extends TestCase
+{
+    public function testAddCommandWithRegularCommand(): void
+    {
+        $application = new Application(false);
+        $command = new Command('test:command');
+
+        $result = $application->addCommand($command);
+
+        self::assertSame($command, $result);
+        self::assertTrue($application->has('test:command'));
+    }
+
+    public function testAddCommandWithContainerAwareCommand(): void
+    {
+        $application = new Application(false);
+        $command = new RegDebugCommand();
+
+        $result = $application->addCommand($command);
+
+        self::assertSame($command, $result);
+        self::assertNotNull($command->getContainer());
+        self::assertTrue($application->has('reg:debug'));
+    }
+
+    public function testAddCommandWithLintCommand(): void
+    {
+        $application = new Application(false);
+        $command = new LintCommand();
+
+        $result = $application->addCommand($command);
+
+        self::assertSame($command, $result);
+        self::assertNotNull($command->getContainer());
+        self::assertTrue($application->has('lint'));
+    }
+
+    public function testAddCommandReplacesExistingCommandWithSameName(): void
+    {
+        $application = new Application(false);
+        $command1 = new Command('test:command');
+        $command2 = new Command('test:command');
+
+        $result1 = $application->addCommand($command1);
+        $result2 = $application->addCommand($command2);
+
+        // The first command should be returned
+        self::assertSame($command1, $result1);
+        // The second command should replace the first one
+        self::assertSame($command2, $result2);
+        // The application should have the second command registered
+        self::assertSame($command2, $application->get('test:command'));
+    }
+
+    public function testAddCommandSetsContainerForContainerAwareCommand(): void
+    {
+        $application = new Application(false);
+        $command = new RegDebugCommand();
+
+        // Before adding, container should be null
+        self::assertNull($command->getContainer());
+
+        $application->addCommand($command);
+
+        // After adding, container should be set
+        self::assertNotNull($command->getContainer());
+    }
+
+    public function testAddCommandDoesNotSetContainerForRegularCommand(): void
+    {
+        $application = new Application(false);
+        $command = new Command('regular:command');
+
+        // Regular commands don't have getContainer method, so we just verify it doesn't crash
+        $result = $application->addCommand($command);
+
+        self::assertSame($command, $result);
+        self::assertTrue($application->has('regular:command'));
+    }
+
+    public function testAddCommandFallsBackToAddWhenAddCommandDoesNotExist(): void
+    {
+        // Create a test Application class that simulates Symfony Console < 8.0
+        // by implementing the same logic but testing the fallback path
+        $legacyApplication = new class('test', '1.0.0') extends BaseApplication {
+            private Container $container;
+
+            public function __construct(string $name = 'test', string $version = '1.0.0')
+            {
+                parent::__construct($name, $version);
+                $this->container = new Container();
+            }
+
+            /**
+             * This method simulates Application::addCommand() but forces the fallback to add()
+             * by checking a different class name that doesn't have addCommand
+             */
+            public function addCommandLegacy(callable|Command $command): ?Command
+            {
+                if ($command instanceof ContainerAwareCommand) {
+                    $command->setContainer($this->container);
+                }
+
+                // Force the fallback path by checking a class that doesn't have addCommand
+                // We use stdClass which definitely doesn't have addCommand
+                if (!method_exists(\stdClass::class, 'addCommand')) {
+                    // For Symfony Console < 8.0, ensure we only pass Command instances
+                    if (!$command instanceof Command) {
+                        throw new \InvalidArgumentException('Command must be an instance of ' . Command::class . ' for Symfony Console < 8.0');
+                    }
+                    return parent::add($command);
+                }
+
+                return parent::addCommand($command);
+            }
+        };
+
+        // Test that the fallback to add() works correctly
+        $command = new Command('legacy:test');
+        $result = $legacyApplication->addCommandLegacy($command);
+
+        self::assertSame($command, $result);
+        self::assertTrue($legacyApplication->has('legacy:test'));
+
+        // Test that ContainerAwareCommand gets its container set
+        $containerAwareCommand = new RegDebugCommand();
+        self::assertNull($containerAwareCommand->getContainer());
+
+        $legacyApplication->addCommandLegacy($containerAwareCommand);
+        self::assertNotNull($containerAwareCommand->getContainer());
+
+        // Test that callable throws exception on old versions
+        $callable = function () {
+            return new Command('callable:command');
+        };
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Command must be an instance of');
+        $legacyApplication->addCommandLegacy($callable);
+    }
+}

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace FriendsOfTwig\Twigcs\Tests\Unit\Console;
 
-use FriendsOfTwig\Twigcs\Container;
 use FriendsOfTwig\Twigcs\Console\Application;
 use FriendsOfTwig\Twigcs\Console\ContainerAwareCommand;
 use FriendsOfTwig\Twigcs\Console\LintCommand;
 use FriendsOfTwig\Twigcs\Console\RegDebugCommand;
+use FriendsOfTwig\Twigcs\Container;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
@@ -98,55 +98,49 @@ final class ApplicationTest extends TestCase
         self::assertTrue($application->has('regular:command'));
     }
 
-    public function testAddCommandFallsBackToAddWhenAddCommandDoesNotExist(): void
+    public function testAddCommandWithSymfony80Plus(): void
     {
-        // Create a test Application class that simulates Symfony Console < 8.0
-        // by implementing the same logic but testing the fallback path
-        $legacyApplication = new class('test', '1.0.0') extends BaseApplication {
-            private Container $container;
+        // Skip this test if we're not on Symfony 8.0+
+        if (!method_exists(BaseApplication::class, 'addCommand')) {
+            self::markTestSkipped('This test requires Symfony Console 8.0+');
+        }
 
-            public function __construct(string $name = 'test', string $version = '1.0.0')
-            {
-                parent::__construct($name, $version);
-                $this->container = new Container();
-            }
+        $application = new Application(false);
+        $command = new Command('test:command');
 
-            /**
-             * This method simulates Application::addCommand() but forces the fallback to add()
-             * by checking a different class name that doesn't have addCommand
-             */
-            public function addCommandLegacy(callable|Command $command): ?Command
-            {
-                if ($command instanceof ContainerAwareCommand) {
-                    $command->setContainer($this->container);
-                }
-
-                // Force the fallback path by checking a class that doesn't have addCommand
-                // We use stdClass which definitely doesn't have addCommand
-                if (!method_exists(\stdClass::class, 'addCommand')) {
-                    // For Symfony Console < 8.0, ensure we only pass Command instances
-                    if (!$command instanceof Command) {
-                        throw new \InvalidArgumentException('Command must be an instance of ' . Command::class . ' for Symfony Console < 8.0');
-                    }
-                    return parent::add($command);
-                }
-
-                return parent::addCommand($command);
-            }
-        };
-
-        // Test that the fallback to add() works correctly
-        $command = new Command('legacy:test');
-        $result = $legacyApplication->addCommandLegacy($command);
+        $result = $application->addCommand($command);
 
         self::assertSame($command, $result);
-        self::assertTrue($legacyApplication->has('legacy:test'));
+        self::assertTrue($application->has('test:command'));
 
         // Test that ContainerAwareCommand gets its container set
         $containerAwareCommand = new RegDebugCommand();
         self::assertNull($containerAwareCommand->getContainer());
 
-        $legacyApplication->addCommandLegacy($containerAwareCommand);
+        $application->addCommand($containerAwareCommand);
+        self::assertNotNull($containerAwareCommand->getContainer());
+    }
+
+    public function testAddCommandFallsBackToAddWithSymfonyBefore80(): void
+    {
+        // Skip this test if we're on Symfony 8.0+
+        if (method_exists(BaseApplication::class, 'addCommand')) {
+            self::markTestSkipped('This test requires Symfony Console < 8.0');
+        }
+
+        $application = new Application(false);
+        $command = new Command('test:command');
+
+        $result = $application->addCommand($command);
+
+        self::assertSame($command, $result);
+        self::assertTrue($application->has('test:command'));
+
+        // Test that ContainerAwareCommand gets its container set
+        $containerAwareCommand = new RegDebugCommand();
+        self::assertNull($containerAwareCommand->getContainer());
+
+        $application->addCommand($containerAwareCommand);
         self::assertNotNull($containerAwareCommand->getContainer());
 
         // Test that callable throws exception on old versions
@@ -156,6 +150,6 @@ final class ApplicationTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Command must be an instance of');
-        $legacyApplication->addCommandLegacy($callable);
+        $application->addCommand($callable);
     }
 }


### PR DESCRIPTION
This pull request fix an issue with the Symfony Console 8.0 : it allow to determine which `add` or `addCommand` method for `Application` class should be called depending on the Symfony Console version.
The `if (method_exists...` test is added to keep the compatibility with previous Symfony Console versions.

Fixes #352.